### PR TITLE
Refine page layouts and unify global styling

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,87 +1,119 @@
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
+
+const tiers = [
+  { name: "Starter", price: "£1 / year", access: "Play 1 full game" },
+  { name: "Explorer", price: "£2 / year", access: "Unlock 3 full games" },
+  { name: "Champion", price: "£3 / year", access: "Enjoy 10 full games" },
+];
+
+const categories = [
+  "Retro remixes for quick wins",
+  "Educational quests (math, words, logic)",
+  "Build & create sandboxes",
+  "AI-assisted experiments",
+];
+
+const safetyPoints = [
+  "No downloads – everything runs inside the browser sandbox.",
+  "Playable previews load inside an iframe with restricted permissions.",
+  "Security headers such as Referrer-Policy and Permissions-Policy are enabled by default.",
+  "Keeping your browser up to date gives the best protection.",
+];
+
 export const metadata = {
-  title: 'About • Games Inc Jr',
-  description: 'Our story, subscriptions, categories, previews, and how to suggest games.'
+  title: "About • Games Inc Jr",
+  description: "Our story, subscriptions, categories, previews, and how to suggest games.",
 };
 
 export default function AboutPage() {
   return (
-    <main className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-16">
-        <div className="max-w-4xl mx-auto bg-white rounded-2xl shadow-xl p-8 mb-8">
-          <h1 className="pixel-text text-5xl text-gray-900 mb-4">About Games inc. Jr</h1>
-          <p className="modern-text text-gray-700 text-lg">
-            Games inc. Jr is a playful game studio run by a talented 7-year-old who builds games using AI tools.
-            We release new games regularly, and any game you purchase will receive <span className="font-semibold">free new levels</span> over time.
-          </p>
-        </div>
+    <PageShell>
+      <div className="mx-auto flex max-w-5xl flex-col gap-16">
+        <PageHeader
+          align="left"
+          eyebrow="Inside the studio"
+          title="Games Inc Jr in a nutshell"
+          description="Games inc. Jr is a playful studio led by a very determined 7-year-old and guided by educators. We prototype with AI tools so ideas can ship quickly, and every released game keeps receiving free level updates."
+        />
 
-        {/* Suggest a Game - Callout */}
-        <section className="bg-white rounded-2xl border border-gray-200 p-6 mb-8 shadow">
-          <h2 className="heading-text text-2xl text-gray-900 mb-3">Suggest a Game</h2>
-          <p className="modern-text text-gray-700 mb-2">
-            Got an idea? <a className="underline" href="mailto:hello@gamesincjr.com">Contact us</a> with your dream game and we will try to build it. If we ship it, we&apos;ll add it to your subscription <span className="font-semibold">for free</span>.
-          </p>
-          <p className="modern-text text-gray-600 text-sm">We love building with the community.</p>
-        </section>
-
-        {/* Subscriptions */}
-        <section className="bg-white rounded-2xl border border-gray-200 p-6 mb-8 shadow">
-          <h2 className="heading-text text-2xl text-gray-900 mb-3">Subscriptions</h2>
-          <p className="modern-text text-gray-700 mb-4">Try level 1 of each game for free, then subscribe to unlock the remaining levels. Simple, affordable tiers:</p>
-          <ul className="modern-text text-gray-800 grid sm:grid-cols-3 gap-4">
-            <li className="bg-gray-50 rounded-xl p-4 border border-gray-200"><strong>Starter</strong> — £1/year • Access 1 game</li>
-            <li className="bg-gray-50 rounded-xl p-4 border border-gray-200"><strong>Explorer</strong> — £2/year • Access 3 games</li>
-            <li className="bg-gray-50 rounded-xl p-4 border border-gray-200"><strong>Champion</strong> — £3/year • Access 10 games</li>
-          </ul>
-          <div className="modern-text text-gray-700 mt-4">
-            <p className="mb-1"><strong>Premium AI Tier</strong> — For games with live AI features (e.g., smart NPCs or generative levels), a small recurring add‑on may apply to cover API costs.</p>
-            <p>We&apos;ll always keep prices as low as possible.</p>
+        <section className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+            <h2 className="text-2xl font-semibold text-slate-900">Suggest a game</h2>
+            <p className="mt-4 text-base leading-7 text-slate-600">
+              Got an idea? <a className="font-semibold text-sky-600 underline" href="mailto:hello@gamesincjr.com">Email us</a> with your dream game and we&apos;ll see if we can bring it to life. If we ship it, it&apos;s added to your subscription <strong>for free</strong>.
+            </p>
+            <p className="mt-3 text-sm text-slate-500">We love building with the community.</p>
           </div>
-          <p className="modern-text text-gray-700 mt-4">Own a game? You&apos;ll get <strong>free level updates</strong> forever.</p>
-          <p className="modern-text text-gray-600 mt-2 text-sm">Subscriptions do not auto‑renew. We&apos;ll ask you before the year ends if you want to re‑subscribe.</p>
-        </section>
-
-        {/* Categories */}
-        <section className="bg-white rounded-2xl border border-gray-200 p-6 mb-8 shadow">
-          <h2 className="heading-text text-2xl text-gray-900 mb-3">Categories</h2>
-          <div className="grid md:grid-cols-4 gap-4 modern-text">
-            <div className="bg-gray-50 rounded-xl p-4 border border-gray-200">🎮 Retro Classics (simple, fun remixes)</div>
-            <div className="bg-gray-50 rounded-xl p-4 border border-gray-200">📚 Educational (math, words, logic)</div>
-            <div className="bg-gray-50 rounded-xl p-4 border border-gray-200">🧱 Building & Creativity (sandboxes)</div>
-            <div className="bg-gray-50 rounded-xl p-4 border border-gray-200">🤖 AI-Integrated (smart NPCs, gen levels)</div>
+          <div className="rounded-3xl bg-sky-50/70 p-8 shadow-lg ring-1 ring-sky-100">
+            <h3 className="text-lg font-semibold text-slate-900">Quick facts</h3>
+            <ul className="mt-4 space-y-3 text-sm leading-6 text-slate-600">
+              <li>✓ New games drop regularly with no extra charge for existing owners.</li>
+              <li>✓ Level one is always free so families can test before subscribing.</li>
+              <li>✓ Parent dashboards highlight play time, favourites and achievements.</li>
+            </ul>
           </div>
         </section>
 
-        {/* How Previews Work */}
-        <section className="bg-white rounded-2xl border border-gray-200 p-6 mb-6 shadow">
-          <h2 className="heading-text text-2xl text-gray-900 mb-3">How Previews Work</h2>
-          <ol className="list-decimal pl-5 space-y-2 modern-text text-gray-700">
-            <li>Click or tap the game area to focus controls. On mobile, use the on-screen buttons.</li>
-            <li>You can play level 1 for a limited time to try the mechanics.</li>
-            <li>Subscribe to unlock all levels for the games in your tier.</li>
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <h2 className="text-2xl font-semibold text-slate-900">Subscriptions that stay simple</h2>
+          <p className="mt-4 text-base leading-7 text-slate-600">
+            Try the first level of every game for free. When you&apos;re ready for more, choose a tier that fits how much you want to explore.
+          </p>
+          <div className="mt-8 grid gap-4 sm:grid-cols-3">
+            {tiers.map((tier) => (
+              <div key={tier.name} className="rounded-2xl bg-slate-50/60 p-5 text-center shadow-inner ring-1 ring-slate-100">
+                <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">{tier.name}</p>
+                <p className="mt-3 text-xl font-bold text-slate-900">{tier.price}</p>
+                <p className="mt-2 text-sm text-slate-600">{tier.access}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-6 space-y-2 text-sm leading-6 text-slate-600">
+            <p>
+              <strong>Premium AI</strong> is an optional add-on tier. It keeps always-on AI features running smoothly by covering the API costs.
+            </p>
+            <p>Subscriptions do not auto-renew—we&apos;ll check in before the year ends.</p>
+            <p>If you purchase a game outright you keep receiving new levels at no extra cost.</p>
+          </div>
+        </section>
+
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <h2 className="text-2xl font-semibold text-slate-900">What we love to build</h2>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            {categories.map((category) => (
+              <div key={category} className="rounded-2xl bg-slate-50/70 p-5 text-sm font-medium text-slate-700 ring-1 ring-slate-100">
+                {category}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <h2 className="text-2xl font-semibold text-slate-900">Previewing games</h2>
+          <ol className="mt-4 list-decimal space-y-3 pl-5 text-base leading-7 text-slate-600">
+            <li>Click the game area to focus controls. On mobile, on-screen buttons help out.</li>
+            <li>Level one is available to try so you can feel the mechanics and pacing.</li>
+            <li>Sign in and upgrade your tier to unlock every level.</li>
           </ol>
         </section>
 
-        {/* Security & Safety */}
-        <section className="bg-white rounded-2xl border border-gray-200 p-6 mb-6 shadow">
-          <h2 className="heading-text text-2xl text-gray-900 mb-3">Security & Safety</h2>
-          <ul className="list-disc pl-5 modern-text text-gray-700 space-y-2">
-            <li>No downloads — everything runs in your web browser.</li>
-            <li>Games load in a browser sandbox (iframe) with restricted permissions.</li>
-            <li>We set security headers (e.g., Referrer-Policy, X-Frame-Options, Permissions-Policy) to reduce risk.</li>
-            <li>We never ask you to install executables to play a game.</li>
+        <section className="rounded-3xl bg-slate-900 p-8 text-slate-100 shadow-2xl ring-1 ring-slate-900/50">
+          <h2 className="text-2xl font-semibold text-white">Security &amp; safety</h2>
+          <ul className="mt-4 space-y-3 text-sm leading-6 text-slate-200">
+            {safetyPoints.map((point) => (
+              <li key={point} className="flex gap-3">
+                <span className="mt-0.5 text-lg text-amber-300">★</span>
+                <span>{point}</span>
+              </li>
+            ))}
           </ul>
-          <p className="modern-text text-gray-500 text-sm mt-3">While browser sandboxing greatly reduces malware risk, no system is 100% immune. Always keep your browser up to date.</p>
         </section>
 
-        {/* Footnote */}
-        <p className="modern-text text-gray-500 text-xs max-w-3xl">
-          Note: We welcome ideas and suggestions from our community. If your suggestion inspires a game we develop,
-          all intellectual property (IP) in the resulting game will be owned by Games inc. Jr.
+        <p className="text-xs leading-6 text-slate-500">
+          We welcome ideas and suggestions from our community. If your suggestion inspires a game we develop, all intellectual property (IP) in the resulting game belongs to Games inc. Jr.
         </p>
       </div>
-    </main>
+    </PageShell>
   );
 }
-
-

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,59 +1,93 @@
-import { getUserFromCookies, type Tier } from '@/lib/user-session';
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
+import { getUserFromCookies, type Tier } from "@/lib/user-session";
 
-export const metadata = { title: 'Account • Games Inc Jr' };
+export const metadata = { title: "Account • Games Inc Jr" };
 
 export default async function AccountPage() {
   const user = await getUserFromCookies();
-  return (
-    <main className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-16">
-        <div className="max-w-xl mx-auto bg-white rounded-2xl p-8 shadow">
-          <h1 className="pixel-text text-3xl text-gray-900 mb-4">Account</h1>
-          <p className="modern-text text-gray-700 mb-6">Signed in as: {user.email || 'Guest'}</p>
 
+  return (
+    <PageShell>
+      <div className="mx-auto flex max-w-xl flex-col gap-10">
+        <PageHeader
+          align="left"
+          eyebrow="Manage access"
+          title="Account settings"
+          description={`Signed in as ${user.email || "a guest"}. Update your email and membership tier below.`}
+        />
+
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
           <form
-            className="space-y-4"
+            className="space-y-5"
             action={async (formData: FormData) => {
-              'use server';
-              const email = String(formData.get('email') || '');
-              const tier = String(formData.get('tier') || 'free') as Tier;
-              await fetch('/api/auth/login', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+              "use server";
+              const email = String(formData.get("email") || "");
+              const tier = String(formData.get("tier") || "free") as Tier;
+              await fetch("/api/auth/login", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ email, tier }),
               });
             }}
           >
-            <div>
-              <label className="block text-sm text-gray-700 mb-1">Email</label>
-              <input name="email" defaultValue={user.email} className="w-full border rounded px-3 py-2" />
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-slate-700" htmlFor="account-email">
+                Email
+              </label>
+              <input
+                id="account-email"
+                name="email"
+                defaultValue={user.email}
+                placeholder="you@example.com"
+                className="w-full rounded-xl border border-slate-200 bg-white/70 px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
             </div>
-            <div>
-              <label className="block text-sm text-gray-700 mb-1">Tier</label>
-              <select name="tier" defaultValue={user.tier} className="w-full border rounded px-3 py-2">
-                <option value="free">Free (previews)</option>
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-slate-700" htmlFor="account-tier">
+                Membership tier
+              </label>
+              <select
+                id="account-tier"
+                name="tier"
+                defaultValue={user.tier}
+                className="w-full rounded-xl border border-slate-200 bg-white/70 px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              >
+                <option value="free">Free (previews only)</option>
                 <option value="starter">Starter (1 game)</option>
                 <option value="explorer">Explorer (3 games)</option>
                 <option value="champion">Champion (10 games)</option>
-                <option value="premium_ai">Premium AI (all + AI)</option>
+                <option value="premium_ai">Premium AI (all games + AI extras)</option>
               </select>
             </div>
-            <button className="gaming-btn" type="submit">Save</button>
+            <button
+              type="submit"
+              className="inline-flex w-full items-center justify-center rounded-xl bg-sky-500 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-sky-500/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+            >
+              Save settings
+            </button>
           </form>
+        </section>
 
+        <section className="rounded-3xl bg-white/70 p-6 text-sm text-slate-600 shadow-inner ring-1 ring-slate-100">
           <form
-            className="mt-6"
             action={async () => {
-              'use server';
-              await fetch('/api/auth/logout', { method: 'POST' });
+              "use server";
+              await fetch("/api/auth/logout", { method: "POST" });
             }}
           >
-            <button className="clean-btn" type="submit">Sign Out</button>
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+            >
+              Sign out
+            </button>
           </form>
-        </div>
+          <p className="mt-4 leading-6">
+            We store your chosen tier in a cookie so game pages know which levels to unlock. Clearing browser data will sign you out.
+          </p>
+        </section>
       </div>
-    </main>
+    </PageShell>
   );
 }
-
-

--- a/src/app/api/scores/save/route.ts
+++ b/src/app/api/scores/save/route.ts
@@ -47,7 +47,8 @@ export async function POST(req: NextRequest) {
     ]);
 
     return NextResponse.json({ ok: true });
-  } catch (e) {
+  } catch (error) {
+    console.error('Failed to save score', error);
     return NextResponse.json({ error: 'Failed to save' }, { status: 500 });
   }
 }

--- a/src/app/api/scores/top/route.ts
+++ b/src/app/api/scores/top/route.ts
@@ -40,7 +40,8 @@ export async function GET(req: NextRequest) {
       }
     }
     return NextResponse.json({ top });
-  } catch (e) {
+  } catch (error) {
+    console.error('Failed to load scores', error);
     return NextResponse.json({ top: [] });
   }
 }

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,15 +1,21 @@
-export const metadata = { title: 'Community • Games Inc Jr' };
+import PageShell from "@/components/PageShell";
+import PageHeader from "@/components/PageHeader";
+import CommunityClient from "./section-client";
 
-import CommunityClient from './section-client';
+export const metadata = { title: "Community • Games Inc Jr" };
 
 export default function CommunityPage() {
   return (
-    <main className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-16">
+    <PageShell>
+      <div className="mx-auto flex max-w-4xl flex-col gap-12">
+        <PageHeader
+          eyebrow="Community hub"
+          title="Share feedback and cheer each other on"
+          description="Drop ideas, celebrate wins and help us shape the next games. Posts refresh automatically, so you can leave a note and check back for replies."
+          align="left"
+        />
         <CommunityClient />
       </div>
-    </main>
+    </PageShell>
   );
 }
-
-

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -1,104 +1,107 @@
-import Link from 'next/link';
+import Image from "next/image";
+import Link from "next/link";
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { getGames } from "@/lib/games";
+
 export const revalidate = 0;
-import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
-import { getGames } from '@/lib/games';
 
 export default function GamesPage() {
   const games = getGames();
-  
+
   return (
-    <div className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-12">
-        <div className="text-center mb-16">
-          <div className="pixel-bounce mb-6">
-            <div className="text-5xl">🎮</div>
-          </div>
-          <h1 className="pixel-text text-5xl font-bold text-yellow-400 mb-6 tracking-wider">
-            OUR GAMES
-          </h1>
-          <p className="text-xl text-cyan-300 max-w-3xl mx-auto leading-relaxed">
-            Discover amazing HTML5 games that you can play instantly in your browser! 
-            <span className="text-orange-400 font-bold"> No downloads, just pure gaming fun!</span>
-          </p>
-        </div>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
+    <PageShell>
+      <div className="flex flex-col gap-16">
+        <PageHeader
+          eyebrow="Play library"
+          title="All of our browser-friendly games"
+          description="Jump into colourful adventures that run right in your browser. Every title includes a free level one preview so you can find new favourites before subscribing."
+          actions={
+            <Link
+              href="/about"
+              className={cn(buttonVariants({ variant: "outline", size: "lg" }), "bg-white/70 backdrop-blur")}
+            >
+              Learn about subscriptions
+            </Link>
+          }
+        />
+
+        <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
           {games.map((game) => (
-            <Link key={game.slug} href={`/games/${game.slug}`}>
-              <Card className="game-card h-full cursor-pointer group">
-                <CardHeader className="p-0">
-                  <div className="aspect-video bg-gradient-to-br from-gray-800 to-gray-900 rounded-t-xl overflow-hidden relative">
-                    <img
-                      src={game.hero || '/placeholder-hero.jpg'}
-                      alt={game.title}
-                      className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
-                    />
-                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>
-                    {game.status === 'coming-soon' && (
-                      <div className="absolute top-4 right-4">
-                        <span className="bg-gradient-to-r from-yellow-400 to-orange-500 text-white px-3 py-1 rounded-full text-xs font-bold shadow-lg">
-                          🚀 Coming Soon
-                        </span>
-                      </div>
-                    )}
-                    <div className="absolute bottom-4 left-4">
-                      <div className="text-white font-bold text-lg">{game.title}</div>
-                    </div>
-                  </div>
-                </CardHeader>
-                
-                <CardContent className="p-6">
-                  <h2 className="font-bold text-xl mb-3 text-gray-800 group-hover:text-orange-600 transition-colors">
-                    {game.title}
-                  </h2>
-                  <p className="text-gray-600 mb-4 leading-relaxed">
-                    {game.description || 'No description available'}
+            <Card key={game.slug} className="group overflow-hidden border-none bg-white/80 shadow-xl ring-1 ring-slate-100 transition hover:-translate-y-1 hover:shadow-2xl">
+              <CardHeader className="relative h-48 overflow-hidden p-0">
+                <div className="absolute inset-0 bg-gradient-to-br from-slate-900/20 to-slate-900/60 opacity-0 transition group-hover:opacity-100" />
+                <Image
+                  src={game.hero || "/placeholder-hero.jpg"}
+                  alt={game.title}
+                  fill
+                  sizes="(min-width: 1280px) 400px, (min-width: 768px) 50vw, 100vw"
+                  className="object-cover transition duration-500 group-hover:scale-105"
+                  priority={game.slug === "alien-unicorn-alliance"}
+                />
+                {game.status === "coming-soon" && (
+                  <span className="absolute right-4 top-4 inline-flex items-center rounded-full bg-slate-900/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">
+                    Coming soon
+                  </span>
+                )}
+              </CardHeader>
+              <CardContent className="space-y-4 py-6">
+                <div>
+                  <h2 className="text-xl font-semibold text-slate-900">{game.title}</h2>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    {game.description || "No description available"}
                   </p>
-                  <div className="flex flex-wrap gap-2 mb-4">
-                    {game.tags?.map((tag) => (
+                </div>
+                {game.tags && (
+                  <div className="flex flex-wrap gap-2">
+                    {game.tags.map((tag) => (
                       <span
                         key={tag}
-                        className="bg-gradient-to-r from-blue-500 to-cyan-400 text-white px-3 py-1 rounded-full text-xs font-bold shadow-sm"
+                        className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-700"
                       >
                         {tag}
                       </span>
                     ))}
                   </div>
-                </CardContent>
-                
-                <CardFooter className="p-6 pt-0">
-                  <div className="flex items-center justify-between w-full">
-                    <div className="text-sm font-semibold text-gray-700 bg-yellow-100 px-3 py-1 rounded-full">
-                      Included with subscription
-                    </div>
-                    <div className="text-sm text-gray-500">
-                      {game.gameType || 'html5'}
-                    </div>
-                  </div>
-                </CardFooter>
-              </Card>
-            </Link>
+                )}
+              </CardContent>
+              <CardFooter className="flex items-center justify-between border-t border-slate-100/80 bg-slate-50/80 py-4">
+                <span className="text-sm font-semibold text-slate-700">Included with membership</span>
+                <Link
+                  href={`/games/${game.slug}`}
+                  className={cn(buttonVariants({ size: "sm" }), "bg-sky-500 text-white hover:bg-sky-500/90")}
+                >
+                  View details
+                </Link>
+              </CardFooter>
+            </Card>
           ))}
-        </div>
+        </section>
 
-        {/* Call to Action */}
-        <div className="text-center mt-16">
-          <div className="bg-gradient-to-r from-orange-500/20 to-yellow-400/20 rounded-2xl p-8 border-2 border-orange-200">
-            <h2 className="pixel-text text-2xl font-bold text-yellow-400 mb-4 tracking-wider">
-              WANT MORE GAMES?
-            </h2>
-            <p className="text-cyan-300 mb-6">
-              New games are added regularly! Check back soon for more adventures.
-            </p>
-            <Link 
-              href="/" 
-              className="gaming-btn gaming-glow text-lg px-8 py-3"
+        <section className="rounded-3xl bg-white/80 p-8 text-center shadow-xl ring-1 ring-slate-100">
+          <h2 className="text-2xl font-semibold text-slate-900">Want to request a game?</h2>
+          <p className="mt-4 text-base leading-7 text-slate-600">
+            We add new adventures every month. Send ideas to <a className="font-semibold text-sky-600 underline" href="mailto:hello@gamesincjr.com">hello@gamesincjr.com</a> and we&apos;ll explore them together.
+          </p>
+          <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Link
+              href="/community"
+              className={cn(buttonVariants({ size: "lg" }), "bg-sky-500 text-white hover:bg-sky-500/90")}
             >
-              🏠 Back to Home
+              Join the community chat
+            </Link>
+            <Link
+              href="/tutorials"
+              className={cn(buttonVariants({ variant: "outline", size: "lg" }), "bg-white/70 backdrop-blur")}
+            >
+              Book a coding tutorial
             </Link>
           </div>
-        </div>
+        </section>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap');
 
 @custom-variant dark (&:is(.dark *));
 
@@ -122,66 +121,8 @@
   }
 }
 
-/* Gaming theme custom styles */
+/* Additional utility overrides */
 @layer utilities {
-  /* Gaming-themed animations */
-  @keyframes pixel-bounce {
-    0%, 100% { transform: translateY(0); }
-    50% { transform: translateY(-4px); }
-  }
-
-  @keyframes glow-pulse {
-    0%, 100% { box-shadow: 0 0 5px rgba(255, 195, 0, 0.3); }
-    50% { box-shadow: 0 0 20px rgba(255, 195, 0, 0.6); }
-  }
-
-  @keyframes controller-glow {
-    0%, 100% { filter: drop-shadow(0 0 5px rgba(255, 107, 53, 0.5)); }
-    50% { filter: drop-shadow(0 0 15px rgba(255, 107, 53, 0.8)); }
-  }
-
-  /* Custom utility classes */
-  .pixel-text {
-    font-family: 'Inter', sans-serif;
-    font-weight: 800;
-    letter-spacing: -0.02em;
-  }
-  
-  .modern-text {
-    font-family: 'Inter', sans-serif;
-    font-weight: 400;
-    line-height: 1.6;
-  }
-  
-  .heading-text {
-    font-family: 'Inter', sans-serif;
-    font-weight: 700;
-    letter-spacing: -0.01em;
-  }
-
-  .gaming-glow {
-    animation: glow-pulse 2s ease-in-out infinite;
-  }
-
-  .controller-glow {
-    animation: controller-glow 3s ease-in-out infinite;
-  }
-
-  .pixel-bounce {
-    animation: pixel-bounce 1s ease-in-out infinite;
-  }
-
-  /* Gaming button styles */
-  .gaming-btn {
-    @apply bg-gradient-to-r from-orange-500 to-yellow-400 text-white font-semibold py-3 px-6 rounded-lg shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200;
-    font-family: 'Inter', sans-serif;
-  }
-
-  .gaming-btn:hover {
-    @apply from-orange-600 to-yellow-500;
-  }
-
-  /* Fullscreen tweaks for game container */
   .fullscreen-target:fullscreen {
     border-radius: 0 !important;
   }
@@ -189,34 +130,11 @@
     width: 100vw;
     height: 100vh;
   }
-  /* Safari/WebKit */
   .fullscreen-target:-webkit-full-screen {
     border-radius: 0 !important;
   }
   .fullscreen-target:-webkit-full-screen .game-viewport {
     width: 100vw;
     height: 100vh;
-  }
-  
-  /* Clean button styles */
-  .clean-btn {
-    @apply bg-white text-gray-800 font-medium py-3 px-6 rounded-lg shadow-md hover:shadow-lg transform hover:scale-105 transition-all duration-200 border border-gray-200;
-    font-family: 'Inter', sans-serif;
-  }
-
-  /* Card hover effects */
-  .game-card {
-    @apply bg-white rounded-xl shadow-lg hover:shadow-2xl transform hover:scale-105 transition-all duration-300 border-2 border-transparent hover:border-orange-200;
-  }
-
-  /* Background patterns */
-  .gaming-bg {
-    background: linear-gradient(135deg, #1A2B4C 0%, #2E86AB 100%);
-  }
-
-  .pixel-pattern {
-    background-image: 
-      radial-gradient(circle at 25% 25%, rgba(255, 195, 0, 0.1) 0%, transparent 50%),
-      radial-gradient(circle at 75% 75%, rgba(255, 107, 53, 0.1) 0%, transparent 50%);
   }
 }

--- a/src/app/it/about/page.tsx
+++ b/src/app/it/about/page.tsx
@@ -1,45 +1,119 @@
-export const metadata = { title: 'Informazioni • Games Inc Jr' };
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
 
-export default function AboutIt() {
+const tiers = [
+  { name: "Starter", price: "£1 / anno", access: "Accesso completo a 1 gioco" },
+  { name: "Explorer", price: "£2 / anno", access: "Sblocca 3 giochi completi" },
+  { name: "Champion", price: "£3 / anno", access: "Accedi a 10 giochi completi" },
+];
+
+const categories = [
+  "Classici retrò rivisitati",
+  "Missioni educative (matematica, parole, logica)",
+  "Sandbox creativi",
+  "Esperimenti con AI attiva",
+];
+
+const safetyPoints = [
+  "Nessun download: tutto gira nel browser.",
+  "Le anteprime si aprono in un iframe con permessi ridotti.",
+  "Abilitiamo intestazioni di sicurezza come Referrer-Policy e Permissions-Policy.",
+  "Mantieni il browser aggiornato per la protezione migliore.",
+];
+
+export const metadata = {
+  title: "Informazioni • Games Inc Jr",
+  description: "La nostra storia, gli abbonamenti, le categorie e come suggerire giochi.",
+};
+
+export default function AboutItPage() {
   return (
-    <main className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-16">
-        <div className="max-w-4xl mx-auto bg-white rounded-2xl shadow-xl p-8 mb-8">
-          <h1 className="pixel-text text-5xl text-gray-900 mb-4">Chi siamo</h1>
-          <p className="modern-text text-gray-700 text-lg">
-            Games inc. Jr è uno studio di gioco gestito da un talentuoso bambino di 7 anni che crea
-            giochi con strumenti di intelligenza artificiale. Aggiungiamo nuovi giochi regolarmente e,
-            se acquisti un gioco, riceverai <strong>nuovi livelli gratuiti</strong> nel tempo.
+    <PageShell>
+      <div className="mx-auto flex max-w-5xl flex-col gap-16">
+        <PageHeader
+          align="left"
+          eyebrow="Dentro lo studio"
+          title="Cos’è Games inc. Jr"
+          description="Games inc. Jr è uno studio giocoso guidato da una bambina determinata e supportato da educatori. Prototipiamo con strumenti AI per pubblicare velocemente e ogni gioco riceve aggiornamenti gratuiti."
+        />
+
+        <section className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+            <h2 className="text-2xl font-semibold text-slate-900">Suggerisci un gioco</h2>
+            <p className="mt-4 text-base leading-7 text-slate-600">
+              Hai un&apos;idea? <a className="font-semibold text-sky-600 underline" href="mailto:hello@gamesincjr.com">Scrivici</a> e proveremo a realizzarla. Se la pubblichiamo verrà aggiunta al tuo abbonamento <strong>senza costi</strong>.
+            </p>
+            <p className="mt-3 text-sm text-slate-500">Ci piace costruire con la community.</p>
+          </div>
+          <div className="rounded-3xl bg-sky-50/70 p-8 shadow-lg ring-1 ring-sky-100">
+            <h3 className="text-lg font-semibold text-slate-900">Punti rapidi</h3>
+            <ul className="mt-4 space-y-3 text-sm leading-6 text-slate-600">
+              <li>✓ Rilasciamo giochi nuovi regolarmente, senza costi extra per chi è già abbonato.</li>
+              <li>✓ Il primo livello è sempre gratuito per provare prima di decidere.</li>
+              <li>✓ I genitori vedono progressi, preferiti e tempo di gioco.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <h2 className="text-2xl font-semibold text-slate-900">Abbonamenti semplici</h2>
+          <p className="mt-4 text-base leading-7 text-slate-600">
+            Prova il primo livello di ogni gioco gratis. Quando vuoi continuare scegli il livello che si adatta alla tua famiglia.
           </p>
-        </div>
-
-        <section className="bg-white rounded-2xl border border-gray-200 p-6 mb-8 shadow">
-          <h2 className="heading-text text-2xl text-gray-900 mb-3">Suggerisci un gioco</h2>
-          <p className="modern-text text-gray-700">Hai un&apos;idea? Scrivici a <a className="underline" href="mailto:hello@gamesincjr.com">hello@gamesincjr.com</a>. Se la realizziamo, sarà aggiunta al tuo abbonamento senza costi aggiuntivi.</p>
+          <div className="mt-8 grid gap-4 sm:grid-cols-3">
+            {tiers.map((tier) => (
+              <div key={tier.name} className="rounded-2xl bg-slate-50/60 p-5 text-center shadow-inner ring-1 ring-slate-100">
+                <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">{tier.name}</p>
+                <p className="mt-3 text-xl font-bold text-slate-900">{tier.price}</p>
+                <p className="mt-2 text-sm text-slate-600">{tier.access}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-6 space-y-2 text-sm leading-6 text-slate-600">
+            <p>
+              <strong>Premium AI</strong> è un livello aggiuntivo facoltativo per coprire i costi delle funzionalità AI sempre attive.
+            </p>
+            <p>Gli abbonamenti non si rinnovano automaticamente: ti avvisiamo prima della scadenza.</p>
+            <p>Se acquisti un gioco, riceverai comunque i nuovi livelli senza pagare altro.</p>
+          </div>
         </section>
 
-        <section className="bg-white rounded-2xl border border-gray-200 p-6 mb-8 shadow">
-          <h2 className="heading-text text-2xl text-gray-900 mb-3">Abbonamenti</h2>
-          <ul className="modern-text text-gray-800 grid sm:grid-cols-3 gap-4">
-            <li className="bg-gray-50 rounded-xl p-4 border">Starter — £1/anno • 1 gioco</li>
-            <li className="bg-gray-50 rounded-xl p-4 border">Explorer — £2/anno • 3 giochi</li>
-            <li className="bg-gray-50 rounded-xl p-4 border">Champion — £3/anno • 10 giochi</li>
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <h2 className="text-2xl font-semibold text-slate-900">Cosa ci piace creare</h2>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            {categories.map((category) => (
+              <div key={category} className="rounded-2xl bg-slate-50/70 p-5 text-sm font-medium text-slate-700 ring-1 ring-slate-100">
+                {category}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <h2 className="text-2xl font-semibold text-slate-900">Come funzionano le anteprime</h2>
+          <ol className="mt-4 list-decimal space-y-3 pl-5 text-base leading-7 text-slate-600">
+            <li>Clicca sul gioco per attivare i controlli. Su mobile usiamo pulsanti a schermo.</li>
+            <li>Puoi giocare il primo livello per capire ritmo e meccaniche.</li>
+            <li>Accedi e scegli un livello di abbonamento per sbloccare tutto.</li>
+          </ol>
+        </section>
+
+        <section className="rounded-3xl bg-slate-900 p-8 text-slate-100 shadow-2xl ring-1 ring-slate-900/50">
+          <h2 className="text-2xl font-semibold text-white">Sicurezza</h2>
+          <ul className="mt-4 space-y-3 text-sm leading-6 text-slate-200">
+            {safetyPoints.map((point) => (
+              <li key={point} className="flex gap-3">
+                <span className="mt-0.5 text-lg text-amber-300">★</span>
+                <span>{point}</span>
+              </li>
+            ))}
           </ul>
-          <p className="modern-text text-gray-700 mt-4"><strong>Livello AI Premium</strong> — per funzionalità AI in tempo reale potrebbe essere applicato un piccolo costo ricorrente per coprire le API.</p>
-          <p className="modern-text text-gray-600 mt-2 text-sm">Gli abbonamenti non si rinnovano automaticamente: ti chiederemo a fine anno se vuoi rinnovare.</p>
         </section>
 
-        <section className="bg-white rounded-2xl border border-gray-200 p-6 mb-6 shadow">
-          <h2 className="heading-text text-2xl text-gray-900 mb-3">Sicurezza</h2>
-          <ul className="list-disc pl-5 modern-text text-gray-700 space-y-2">
-            <li>Nessun download — tutto nel browser.</li>
-            <li>Giochi in iframe sandbox con permessi limitati.</li>
-            <li>Header di sicurezza attivi.</li>
-          </ul>
-        </section>
+        <p className="text-xs leading-6 text-slate-500">
+          Le idee della community sono benvenute. Se una proposta ispira un nuovo gioco, la proprietà intellettuale rimane di Games inc. Jr.
+        </p>
       </div>
-    </main>
+    </PageShell>
   );
 }
-
-

--- a/src/app/it/account/page.tsx
+++ b/src/app/it/account/page.tsx
@@ -1,35 +1,93 @@
-import { getUserFromCookies, type Tier } from '@/lib/user-session';
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
+import { getUserFromCookies, type Tier } from "@/lib/user-session";
 
-export const metadata = { title: 'Account • Games Inc Jr' };
+export const metadata = { title: "Account • Games Inc Jr" };
 
-export default async function AccountIt() {
+export default async function AccountItPage() {
   const user = await getUserFromCookies();
+
   return (
-    <main className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-16">
-        <div className="max-w-xl mx-auto bg-white rounded-2xl p-8 shadow">
-          <h1 className="pixel-text text-3xl text-gray-900 mb-4">Account</h1>
-          <p className="modern-text text-gray-700 mb-6">Accesso come: {user.email || 'Ospite'}</p>
-          <form className="space-y-4" action={async (fd: FormData) => { 'use server'; const email=String(fd.get('email')||''); const tier=String(fd.get('tier')||'free') as Tier; await fetch('/api/auth/login',{method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email, tier})}); }}>
-            <div><label className="block text-sm text-gray-700 mb-1">Email</label><input name="email" defaultValue={user.email} className="w-full border rounded px-3 py-2" /></div>
-            <div><label className="block text-sm text-gray-700 mb-1">Livello</label>
-              <select name="tier" defaultValue={user.tier} className="w-full border rounded px-3 py-2">
-                <option value="free">Gratis (anteprime)</option>
+    <PageShell>
+      <div className="mx-auto flex max-w-xl flex-col gap-10">
+        <PageHeader
+          align="left"
+          eyebrow="Gestisci accesso"
+          title="Impostazioni account"
+          description={`Accesso come ${user.email || "ospite"}. Aggiorna email e livello di abbonamento qui sotto.`}
+        />
+
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <form
+            className="space-y-5"
+            action={async (formData: FormData) => {
+              "use server";
+              const email = String(formData.get("email") || "");
+              const tier = String(formData.get("tier") || "free") as Tier;
+              await fetch("/api/auth/login", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ email, tier }),
+              });
+            }}
+          >
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-slate-700" htmlFor="account-email-it">
+                Email
+              </label>
+              <input
+                id="account-email-it"
+                name="email"
+                defaultValue={user.email}
+                placeholder="tu@esempio.com"
+                className="w-full rounded-xl border border-slate-200 bg-white/70 px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-slate-700" htmlFor="account-tier-it">
+                Livello abbonamento
+              </label>
+              <select
+                id="account-tier-it"
+                name="tier"
+                defaultValue={user.tier}
+                className="w-full rounded-xl border border-slate-200 bg-white/70 px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              >
+                <option value="free">Free (solo anteprime)</option>
                 <option value="starter">Starter (1 gioco)</option>
                 <option value="explorer">Explorer (3 giochi)</option>
                 <option value="champion">Champion (10 giochi)</option>
-                <option value="premium_ai">AI Premium</option>
+                <option value="premium_ai">Premium AI (tutti i giochi + AI)</option>
               </select>
             </div>
-            <button className="gaming-btn" type="submit">Salva</button>
+            <button
+              type="submit"
+              className="inline-flex w-full items-center justify-center rounded-xl bg-sky-500 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-sky-500/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+            >
+              Salva impostazioni
+            </button>
           </form>
-          <form className="mt-6" action={async ()=>{ 'use server'; await fetch('/api/auth/logout',{method:'POST'}); }}>
-            <button className="clean-btn" type="submit">Esci</button>
+        </section>
+
+        <section className="rounded-3xl bg-white/70 p-6 text-sm text-slate-600 shadow-inner ring-1 ring-slate-100">
+          <form
+            action={async () => {
+              "use server";
+              await fetch("/api/auth/logout", { method: "POST" });
+            }}
+          >
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+            >
+              Esci
+            </button>
           </form>
-        </div>
+          <p className="mt-4 leading-6">
+            Conserviamo il livello scelto in un cookie per sapere quali livelli sbloccare. Svuotare i dati del browser termina l&apos;accesso.
+          </p>
+        </section>
       </div>
-    </main>
+    </PageShell>
   );
 }
-
-

--- a/src/app/it/community/page.tsx
+++ b/src/app/it/community/page.tsx
@@ -1,14 +1,36 @@
-export const metadata = { title: 'Comunità • Games Inc Jr' };
-import CommunityClient from '../../community/section-client';
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
+import CommunityClient, { type CommunityCopy } from "@/app/community/section-client";
 
-export default function CommunityIt() {
+export const metadata = { title: "Community • Games Inc Jr" };
+
+const copy: Partial<CommunityCopy> = {
+  intro: "Condividi idee, feedback e festeggia i progressi con altri giocatori.",
+  displayNameLabel: "Nome visibile (facoltativo)",
+  displayNamePlaceholder: "es. SuperCoder",
+  messageLabel: "Messaggio",
+  messagePlaceholder: "Scrivi un suggerimento, un bug o qualcosa da festeggiare.",
+  emptyState: "Nessun messaggio per ora: lascia tu il primo!",
+  postButton: "Pubblica",
+  posting: "Invio…",
+  errorEmpty: "Scrivi qualcosa prima di pubblicare.",
+  errorRefresh: "Non riusciamo ad aggiornare il feed. Riproviamo automaticamente.",
+  errorSubmit: "Non siamo riusciti a pubblicare. Riprova più tardi.",
+  characterHint: "I messaggi sono limitati a 500 caratteri per letture rapide.",
+};
+
+export default function CommunityItPage() {
   return (
-    <main className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-16">
-        <CommunityClient />
+    <PageShell>
+      <div className="mx-auto flex max-w-4xl flex-col gap-12">
+        <PageHeader
+          align="left"
+          eyebrow="Community"
+          title="Parla con noi e con la community"
+          description="Lascia un messaggio: le note si aggiornano automaticamente così puoi tornare a leggere le risposte quando vuoi."
+        />
+        <CommunityClient copy={copy} />
       </div>
-    </main>
+    </PageShell>
   );
 }
-
-

--- a/src/app/it/games/[slug]/page.tsx
+++ b/src/app/it/games/[slug]/page.tsx
@@ -1,26 +1,150 @@
-import { notFound } from 'next/navigation';
-import { getGameBySlug } from '@/lib/games';
-import GamePlayer from '@/components/GamePlayer';
+import Image from "next/image";
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import PageShell from "@/components/PageShell";
+import { Button, buttonVariants } from "@/components/ui/button";
+import GamePlayer from "@/components/GamePlayer";
+import ComingSoon from "@/components/ComingSoon";
+import { getGameBySlug } from "@/lib/games";
+import { cn } from "@/lib/utils";
+import { getUserFromCookies, hasAccessToGame } from "@/lib/user-session";
 
-interface Params { params: { slug: string } }
+interface Params {
+  params: { slug: string };
+}
 
-export default function GiocoIt({ params }: Params) {
+export default async function GiocoIt({ params }: Params) {
   const game = getGameBySlug(params.slug);
-  if (!game) notFound();
+  const user = await getUserFromCookies();
+
+  if (!game) {
+    notFound();
+  }
+
+  const description = (game as typeof game & { description_it?: string })?.description_it || game.description || "Nessuna descrizione disponibile";
+
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="mb-8">
-        <h1 className="text-4xl font-bold mb-4">{game.title}</h1>
-        <p className="text-lg text-gray-600">{(game as unknown as { description_it?: string }).description_it || game.description || 'Nessuna descrizione disponibile'}</p>
+    <PageShell>
+      <div className="mx-auto flex max-w-6xl flex-col gap-14">
+        <section className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-700">
+                {game.gameType?.toUpperCase() || "HTML5"}
+              </span>
+              {game.status === "coming-soon" && (
+                <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700">
+                  In arrivo
+                </span>
+              )}
+            </div>
+            <div className="space-y-4">
+              <h1 className="text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl">{game.title}</h1>
+              <p className="text-base leading-7 text-slate-600 sm:text-lg">{description}</p>
+            </div>
+            {game.tags && (
+              <div className="flex flex-wrap gap-2">
+                {game.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center rounded-full bg-sky-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-600 ring-1 ring-sky-100"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="flex flex-wrap items-center gap-3">
+              <Button asChild className="bg-sky-500 text-white hover:bg-sky-500/90">
+                <a href="#demo">Gioca la demo</a>
+              </Button>
+              <a
+                href="/it/about"
+                className={cn(buttonVariants({ variant: "outline" }), "bg-white/80 backdrop-blur")}
+              >
+                Vedi gli abbonamenti
+              </a>
+            </div>
+          </div>
+          <div className="overflow-hidden rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-1 shadow-2xl">
+            <div className="rounded-[26px] bg-slate-900/70 p-6">
+              <div className="relative h-72 w-full overflow-hidden rounded-2xl">
+                <Image
+                  src={game.hero || "/placeholder-hero.jpg"}
+                  alt={game.title}
+                  fill
+                  sizes="(min-width: 1280px) 480px, (min-width: 768px) 50vw, 100vw"
+                  className="object-cover"
+                />
+              </div>
+              <div className="mt-5 space-y-2 rounded-2xl bg-slate-800/60 p-5 text-slate-100">
+                <p className="text-sm font-semibold uppercase tracking-wide text-slate-200">Incluso nell&apos;abbonamento</p>
+                <p className="text-sm text-slate-300">Prova il primo livello gratuitamente, poi accedi per sbloccare tutto.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="demo" className="space-y-6 rounded-3xl bg-white/80 p-8 shadow-xl ring-1 ring-slate-100" data-demo-section>
+          {!hasAccessToGame(user.tier, 0) && (
+            <div className="rounded-2xl bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-900 ring-1 ring-amber-200/70">
+              Modalità anteprima: qui puoi giocare il primo livello. Per sbloccare il resto, scegli un livello sulla pagina <a className="font-semibold text-amber-900 underline" href="/it/about">Informazioni</a> e poi accedi dalla pagina <a className="font-semibold text-amber-900 underline" href="/it/account">Account</a>.
+            </div>
+          )}
+          <GamePlayer game={game} />
+          <Suspense>
+            <Scores slug={game.slug} />
+          </Suspense>
+        </section>
+
+        {game.screenshots?.length ? (
+          <section className="space-y-4">
+            <h2 className="text-2xl font-semibold text-slate-900">Screenshot</h2>
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {game.screenshots.map((screen, index) => (
+                <figure key={screen} className="overflow-hidden rounded-2xl bg-slate-100">
+                  <Image
+                    src={screen}
+                    alt={`${game.title} screenshot ${index + 1}`}
+                    width={640}
+                    height={360}
+                    className="h-full w-full object-cover"
+                  />
+                </figure>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <ComingSoon gameTitle={game.title} hasDemo={!!game.demoPath} />
+        </section>
       </div>
-      <div className="mb-12" data-demo-section>
-        <div className="bg-yellow-50 border border-yellow-200 text-yellow-900 rounded-lg p-4 mb-4">
-          <p>Modalità anteprima: gioca il livello 1. Per sbloccare tutti i livelli, scegli un abbonamento nella pagina Informazioni.</p>
-        </div>
-        <GamePlayer game={game} />
-      </div>
-    </div>
+    </PageShell>
   );
 }
 
-
+async function Scores({ slug }: { slug: string }) {
+  try {
+    const res = await fetch(`${process.env.APP_URL || ""}/api/scores/top?slug=${encodeURIComponent(slug)}`, { cache: "no-store" });
+    const data = await res.json();
+    const top: Array<{ name: string; score: number }> = data?.top || [];
+    if (!top.length) return null;
+    return (
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold text-slate-900">Classifica</h3>
+        <ul className="divide-y divide-slate-200 overflow-hidden rounded-2xl ring-1 ring-slate-100">
+          {top.map((row, index) => (
+            <li key={row.name + row.score} className="flex items-center justify-between bg-white/70 px-4 py-3 text-sm text-slate-700">
+              <span className="font-semibold">#{index + 1} {row.name}</span>
+              <span className="font-bold text-slate-900">{row.score}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}

--- a/src/app/it/games/page.tsx
+++ b/src/app/it/games/page.tsx
@@ -1,61 +1,108 @@
-import Link from 'next/link';
-import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
-import { getGames } from '@/lib/games';
+import Image from "next/image";
+import Link from "next/link";
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { getGames, type Game } from "@/lib/games";
 
 export const revalidate = 0;
 
-export default function GiochiPage() {
-  const games = getGames();
-  return (
-    <div className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-12">
-        <div className="text-center mb-16">
-          <div className="pixel-bounce mb-6"><div className="text-5xl">🎮</div></div>
-          <h1 className="pixel-text text-5xl font-bold text-yellow-400 mb-6 tracking-wider">I NOSTRI GIOCHI</h1>
-          <p className="text-xl text-cyan-300 max-w-3xl mx-auto leading-relaxed">
-            Scopri fantastici giochi HTML5 da giocare subito nel browser!
-            <span className="text-orange-400 font-bold"> Nessun download, solo divertimento!</span>
-          </p>
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
-          {games.map((game) => (
-            <Link key={game.slug} href={`/it/games/${game.slug}`}>
-              <Card className="game-card h-full cursor-pointer group">
-                <CardHeader className="p-0">
-                  <div className="aspect-video bg-gradient-to-br from-gray-800 to-gray-900 rounded-t-xl overflow-hidden relative">
-                    <img src={game.hero || '/placeholder-hero.jpg'} alt={game.title} className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300" />
-                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>
-                    {game.status === 'coming-soon' && (
-                      <div className="absolute top-4 right-4">
-                        <span className="bg-gradient-to-r from-yellow-400 to-orange-500 text-white px-3 py-1 rounded-full text-xs font-bold shadow-lg">🚀 Prossimamente</span>
-                      </div>
-                    )}
-                    <div className="absolute bottom-4 left-4"><div className="text-white font-bold text-lg">{game.title}</div></div>
-                  </div>
-                </CardHeader>
-                <CardContent className="p-6">
-                  <h2 className="font-bold text-xl mb-3 text-gray-800 group-hover:text-orange-600 transition-colors">{game.title}</h2>
-                  <p className="text-gray-600 mb-4 leading-relaxed">{(game as unknown as { description_it?: string }).description_it || game.description || 'Descrizione non disponibile'}</p>
-                  <div className="flex flex-wrap gap-2 mb-4">
-                    {game.tags?.map((tag) => (
-                      <span key={tag} className="bg-gradient-to-r from-blue-500 to-cyan-400 text-white px-3 py-1 rounded-full text-xs font-bold shadow-sm">{tag}</span>
-                    ))}
-                  </div>
-                </CardContent>
-                <CardFooter className="p-6 pt-0">
-                  <div className="flex items-center justify-between w-full">
-                    <div className="text-sm font-semibold text-gray-700 bg-yellow-100 px-3 py-1 rounded-full">Incluso nell&apos;abbonamento</div>
-                    <div className="text-sm text-gray-500">{game.gameType || 'html5'}</div>
-                  </div>
-                </CardFooter>
-              </Card>
-            </Link>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
+function getItalianDescription(game: Game): string {
+  return (game as Game & { description_it?: string }).description_it || game.description || "Descrizione non disponibile";
 }
 
+export default function GiochiPage() {
+  const games = getGames();
 
+  return (
+    <PageShell>
+      <div className="flex flex-col gap-16">
+        <PageHeader
+          eyebrow="Libreria"
+          title="Tutti i nostri giochi nel browser"
+          description="Scopri avventure colorate che partono direttamente dal browser. Ogni titolo offre il primo livello gratuito, così puoi scegliere il preferito prima di abbonarti."
+          actions={
+            <Link
+              href="/it/about"
+              className={cn(buttonVariants({ variant: "outline", size: "lg" }), "bg-white/70 backdrop-blur")}
+            >
+              Scopri gli abbonamenti
+            </Link>
+          }
+          align="left"
+        />
+
+        <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {games.map((game) => (
+            <Card key={game.slug} className="group overflow-hidden border-none bg-white/80 shadow-xl ring-1 ring-slate-100 transition hover:-translate-y-1 hover:shadow-2xl">
+              <CardHeader className="relative h-48 overflow-hidden p-0">
+                <div className="absolute inset-0 bg-gradient-to-br from-slate-900/20 to-slate-900/60 opacity-0 transition group-hover:opacity-100" />
+                <Image
+                  src={game.hero || "/placeholder-hero.jpg"}
+                  alt={game.title}
+                  fill
+                  sizes="(min-width: 1280px) 400px, (min-width: 768px) 50vw, 100vw"
+                  className="object-cover transition duration-500 group-hover:scale-105"
+                  priority={game.slug === "alien-unicorn-alliance"}
+                />
+                {game.status === "coming-soon" && (
+                  <span className="absolute right-4 top-4 inline-flex items-center rounded-full bg-slate-900/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">
+                    Prossimamente
+                  </span>
+                )}
+              </CardHeader>
+              <CardContent className="space-y-4 py-6">
+                <h2 className="text-xl font-semibold text-slate-900">{game.title}</h2>
+                <p className="text-sm leading-6 text-slate-600">{getItalianDescription(game)}</p>
+                {game.tags && (
+                  <div className="flex flex-wrap gap-2">
+                    {game.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-700"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+              <CardFooter className="flex items-center justify-between border-t border-slate-100/80 bg-slate-50/80 py-4">
+                <span className="text-sm font-semibold text-slate-700">Incluso nell&apos;abbonamento</span>
+                <Link
+                  href={`/it/games/${game.slug}`}
+                  className={cn(buttonVariants({ size: "sm" }), "bg-sky-500 text-white hover:bg-sky-500/90")}
+                >
+                  Dettagli
+                </Link>
+              </CardFooter>
+            </Card>
+          ))}
+        </section>
+
+        <section className="rounded-3xl bg-white/80 p-8 text-center shadow-xl ring-1 ring-slate-100">
+          <h2 className="text-2xl font-semibold text-slate-900">Vuoi proporre un nuovo gioco?</h2>
+          <p className="mt-4 text-base leading-7 text-slate-600">
+            Aggiungiamo novità ogni mese. Scrivici su <a className="font-semibold text-sky-600 underline" href="mailto:hello@gamesincjr.com">hello@gamesincjr.com</a> e costruiremo l&apos;idea insieme.
+          </p>
+          <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Link
+              href="/it/community"
+              className={cn(buttonVariants({ size: "lg" }), "bg-sky-500 text-white hover:bg-sky-500/90")}
+            >
+              Entra nella community
+            </Link>
+            <Link
+              href="/it/tutorials"
+              className={cn(buttonVariants({ variant: "outline", size: "lg" }), "bg-white/70 backdrop-blur")}
+            >
+              Prenota un tutorial
+            </Link>
+          </div>
+        </section>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/it/page.tsx
+++ b/src/app/it/page.tsx
@@ -1,97 +1,148 @@
-import Link from 'next/link';
+import Link from "next/link";
+import PageShell from "@/components/PageShell";
+
+const features = [
+  {
+    icon: "⚡",
+    title: "Gioco immediato",
+    description: "Nessuna installazione. Clicchi e giochi direttamente nel browser.",
+  },
+  {
+    icon: "🤖",
+    title: "AI‑assistita",
+    description: "Usiamo l’AI per prototipare e iterare le idee velocemente.",
+  },
+  {
+    icon: "🎯",
+    title: "Chiaro e giocabile",
+    description: "Controlli semplici, grafica leggibile, sessioni brevi.",
+  },
+];
+
+const highlightTags = ["Azione", "Volo", "Combo"];
 
 export default function HomeIt() {
   return (
-    <main className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-20">
-        {/* Hero */}
-        <div className="mb-20">
-          <div className="max-w-4xl mx-auto bg-white rounded-2xl shadow-xl p-10 text-center text-gray-800">
-            <div className="pixel-bounce mb-4"><div className="text-6xl">🎮</div></div>
-            <h1 className="pixel-text text-5xl text-gray-900 mb-2">GAMES inc. Jr</h1>
-            <div className="modern-text text-gray-600 mb-4">per bambini, da bambini. l&apos;immaginazione è l&apos;unico limite</div>
-            <p className="modern-text text-lg mb-6">
-              Benvenuto. Gioca a titoli HTML5 nel browser — da idee retrò semplici a esperimenti assistiti dall&apos;AI.
-              <span className="font-semibold"> Niente download.</span>
+    <PageShell tone="vibrant" className="space-y-20">
+      <section className="mx-auto flex max-w-5xl flex-col items-center gap-10 text-center">
+        <span className="inline-flex items-center rounded-full bg-white/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-sky-600 shadow-sm ring-1 ring-sky-100">
+          Per bambini, da bambini
+        </span>
+        <div className="space-y-6">
+          <h1 className="text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl">
+            Games inc. Jr
+          </h1>
+          <p className="mx-auto max-w-3xl text-base leading-7 text-slate-600 sm:text-lg">
+            L&apos;immaginazione è l&apos;unico limite. Gioca a titoli HTML5 nel browser: dalle idee retrò agli esperimenti assistiti dall&apos;AI.
+            <span className="font-semibold text-slate-900"> Niente download.</span>
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Link
+            href="/games"
+            className="inline-flex items-center justify-center rounded-xl bg-sky-500 px-8 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-sky-500/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          >
+            🎯 Sfoglia i giochi
+          </Link>
+          <Link
+            href="/games/alien-unicorn-alliance"
+            className="inline-flex items-center justify-center rounded-xl bg-white/80 px-8 py-3 text-sm font-semibold text-slate-800 shadow-lg ring-1 ring-slate-200 transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          >
+            🦄 Prova Alien Unicorn Alliance
+          </Link>
+        </div>
+      </section>
+
+      <section className="mx-auto grid max-w-5xl gap-6 sm:grid-cols-3">
+        {features.map((feature) => (
+          <article
+            key={feature.title}
+            className="flex h-full flex-col items-center gap-4 rounded-3xl bg-white/80 p-8 text-center shadow-lg ring-1 ring-slate-100"
+          >
+            <span className="text-4xl">{feature.icon}</span>
+            <h3 className="text-xl font-semibold text-slate-900">{feature.title}</h3>
+            <p className="text-sm leading-6 text-slate-600">{feature.description}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="mx-auto max-w-6xl rounded-3xl bg-white/80 p-10 shadow-xl ring-1 ring-slate-100">
+        <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+          <div className="space-y-6 text-left">
+            <div className="flex items-center gap-3 text-slate-800">
+              <span className="text-3xl">🦄</span>
+              <h2 className="text-3xl font-bold">Alien Unicorn Alliance</h2>
+            </div>
+            <p className="text-base leading-7 text-slate-600">
+              Scivola tra praterie al neon, raccogli cristalli armonici e usa l&apos;impulso stellare per trasformare i droni in bonus scintillanti.
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="/games" className="gaming-btn gaming-glow text-lg px-8 py-4">🎯 Sfoglia i giochi</Link>
-              <Link href="/games/alien-unicorn-alliance" className="clean-btn text-lg px-8 py-4">🦄 Prova Alien Unicorn Alliance</Link>
+            <div className="flex flex-wrap gap-2">
+              {highlightTags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-700"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/games/alien-unicorn-alliance"
+                className="inline-flex items-center justify-center rounded-xl bg-sky-500 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-sky-500/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+              >
+                🎮 Gioca ora
+              </Link>
+              <Link
+                href="/games/alien-unicorn-alliance"
+                className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+              >
+                📖 Dettagli
+              </Link>
+            </div>
+          </div>
+          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-10 text-center text-sky-100 shadow-2xl">
+            <div className="space-y-3">
+              <div className="text-5xl">🌈</div>
+              <p className="text-lg font-semibold text-white">Alien Unicorn Alliance</p>
+              <p className="text-sm text-slate-200">Anteprima giocabile nel browser</p>
             </div>
           </div>
         </div>
+      </section>
 
-        {/* Caratteristiche */}
-        <div className="grid md:grid-cols-3 gap-8 mb-20">
-          <div className="game-card p-8 text-center">
-            <div className="text-5xl mb-6 pixel-bounce">⚡</div>
-            <h3 className="heading-text text-2xl text-gray-800 mb-4">Gioco immediato</h3>
-            <p className="modern-text text-gray-600">Nessuna installazione. Clicca e gioca direttamente nel browser.</p>
-          </div>
-          <div className="game-card p-8 text-center">
-            <div className="text-5xl mb-6 pixel-bounce">🤖</div>
-            <h3 className="text-2xl font-bold text-gray-800 mb-4">AI‑assistita</h3>
-            <p className="text-gray-600 leading-relaxed">Usiamo l&apos;AI per prototipare e iterare le idee più velocemente.</p>
-          </div>
-          <div className="game-card p-8 text-center">
-            <div className="text-5xl mb-6 pixel-bounce">🎯</div>
-            <h3 className="text-2xl font-bold text-gray-800 mb-4">Chiaro & giocabile</h3>
-            <p className="text-gray-600 leading-relaxed">Controlli semplici, grafica leggibile, sessioni brevi.</p>
+      <section className="mx-auto max-w-5xl rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+        <div className="grid gap-6 sm:grid-cols-[auto,1fr] sm:items-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-sky-100 text-3xl">💡</div>
+          <div className="space-y-3 text-left">
+            <h2 className="text-2xl font-semibold text-slate-900">Suggerisci un gioco</h2>
+            <p className="text-sm leading-6 text-slate-600">
+              Hai un&apos;idea? <a className="font-semibold text-sky-600 underline" href="mailto:hello@gamesincjr.com">Scrivici</a> e, se la realizziamo, la aggiungeremo al tuo abbonamento senza costi extra.
+            </p>
           </div>
         </div>
+      </section>
 
-        {/* Gioco in evidenza */}
-        <div className="text-center">
-          <h2 className="pixel-text text-4xl font-bold text-yellow-400 mb-12 tracking-wider">GIOCO IN EVIDENZA</h2>
-          <div className="game-card p-10 max-w-6xl mx-auto">
-            <div className="grid lg:grid-cols-2 gap-12 items-center">
-              <div className="text-left">
-                <div className="flex items-center mb-6"><div className="text-4xl mr-4">🦄</div><h3 className="text-3xl font-bold text-gray-800">Alien Unicorn Alliance</h3></div>
-                <p className="text-gray-600 mb-6 text-lg leading-relaxed">Scivola tra le praterie al neon, raccogli cristalli armonici e usa l&apos;impulso stellare per trasformare i droni alieni in bonus scintillanti.</p>
-                <div className="flex flex-wrap gap-3 mb-8">
-                  <span className="bg-gradient-to-r from-blue-500 to-cyan-400 text-white px-4 py-2 rounded-full text-sm font-bold">Azione</span>
-                  <span className="bg-gradient-to-r from-violet-500 to-purple-400 text-white px-4 py-2 rounded-full text-sm font-bold">Volo</span>
-                  <span className="bg-gradient-to-r from-rose-500 to-pink-400 text-white px-4 py-2 rounded-full text-sm font-bold">Combo</span>
-                </div>
-                <div className="flex flex-col sm:flex-row gap-4">
-                  <Link href="/games/alien-unicorn-alliance" className="gaming-btn gaming-glow text-lg px-8 py-4">🎮 Gioca ora</Link>
-                  <Link href="/games/alien-unicorn-alliance" className="bg-gradient-to-r from-gray-600 to-gray-700 text-white px-8 py-4 rounded-lg text-lg font-bold shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200">📖 Dettagli</Link>
-                </div>
-              </div>
-              <div className="relative">
-                <div className="bg-gradient-to-br from-gray-800 to-gray-900 rounded-2xl h-80 flex items-center justify-center border-4 border-orange-200 shadow-2xl">
-                  <div className="text-center"><div className="text-6xl mb-4">🌈</div><div className="text-cyan-300 font-bold text-lg">Alien Unicorn Alliance</div><div className="text-gray-400 text-sm">Anteprima</div></div>
-                </div>
-              </div>
-            </div>
-          </div>
+      <section className="mx-auto max-w-4xl rounded-3xl bg-white/80 p-10 text-center shadow-xl ring-1 ring-slate-100">
+        <h2 className="text-3xl font-bold text-slate-900">Pronto a giocare?</h2>
+        <p className="mt-4 text-base leading-7 text-slate-600">
+          Unisciti alla community di giovani giocatori e creatori! Niente download: i giochi girano nel browser con permessi limitati.
+        </p>
+        <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+          <Link
+            href="/games"
+            className="inline-flex items-center justify-center rounded-xl bg-sky-500 px-8 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-sky-500/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          >
+            🎯 Inizia ora
+          </Link>
+          <Link
+            href="/community"
+            className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-8 py-3 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+          >
+            💬 Community
+          </Link>
         </div>
-
-        {/* Suggerisci un gioco */}
-        <div className="mt-20 mb-12">
-          <div className="max-w-5xl mx-auto bg-white rounded-2xl shadow-xl p-10">
-            <div className="grid md:grid-cols-3 gap-6 items-center">
-              <div className="text-5xl text-center md:text-left">💡</div>
-              <div className="md:col-span-2">
-                <h3 className="heading-text text-2xl text-gray-900 mb-2">Suggerisci un gioco</h3>
-                <p className="modern-text text-gray-700">Hai un&apos;idea? <a className="underline" href="mailto:hello@gamesincjr.com">Contattaci</a>. Se lo realizziamo, sarà aggiunto al tuo abbonamento senza costi.</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Call to action */}
-        <div className="text-center">
-          <div className="max-w-4xl mx-auto bg-white rounded-2xl p-10 shadow-xl">
-            <h2 className="pixel-text text-3xl text-gray-900 mb-4">Pronto a giocare?</h2>
-            <p className="modern-text text-gray-700 text-lg mb-2">Unisciti alla community di giovani giocatori e creatori! 🎉</p>
-            <p className="modern-text text-gray-600 text-sm mb-6">Niente download — più sicuro. I giochi girano nel browser con permessi limitati.</p>
-            <Link href="/games" className="gaming-btn gaming-glow text-xl px-12 py-5">🎯 Inizia ora</Link>
-          </div>
-        </div>
-      </div>
-    </main>
+      </section>
+    </PageShell>
   );
 }
-
-

--- a/src/app/it/tutorials/page.tsx
+++ b/src/app/it/tutorials/page.tsx
@@ -1,34 +1,44 @@
-export const metadata = { title: 'Tutorial • Games Inc Jr' };
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
 
-export default function TutorialsIt() {
+export const metadata = { title: "Tutorial • Games Inc Jr" };
+
+export default function TutorialsItPage() {
   return (
-    <main className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-16">
-        <div className="max-w-4xl mx-auto bg-white rounded-2xl p-8 shadow">
-          <h1 className="pixel-text text-4xl text-gray-900 mb-4">Tutorial di Coding</h1>
-          <p className="modern-text text-gray-700 mb-6">
-            Offriamo sessioni remote di 30 minuti a <strong>£25 per studente</strong> per mostrare ai
-            bambini (7+) come iniziare con il coding basato su prompt e l&apos;AI.
+    <PageShell>
+      <div className="mx-auto flex max-w-4xl flex-col gap-12">
+        <PageHeader
+          align="left"
+          eyebrow="Sessioni da 30 minuti"
+          title="Tutorial di coding per piccoli curiosi"
+          description="Offriamo sessioni remote mirate (£25 a studente) per mostrare a chi ha 7+ anni come trasformare un’idea in un prototipo con workflow assistiti dall’AI."
+        />
+
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <h2 className="text-xl font-semibold text-slate-900">Perché adesso?</h2>
+          <p className="mt-4 text-base leading-7 text-slate-600">
+            Il settore sta cambiando rapidamente grazie all’AI. Il “vibe coding” — descrivere ciò che vuoi in modo chiaro e iterare velocemente — è ormai normale. Non serve esperienza: basta una visione, comunicazione chiara e voglia di sperimentare.
           </p>
-          <h2 className="heading-text text-2xl text-gray-900 mb-2">Perché adesso?</h2>
-          <p className="modern-text text-gray-700 mb-6">
-            L&apos;industria è cambiata con l&apos;AI. Il “vibe coding” — descrivere chiaramente cosa si vuole e
-            iterare velocemente — è usato sia dalle big tech che dagli sviluppatori indipendenti. Non
-            serve esperienza: visione chiara, comunicazione, attenzione ai dettagli e curiosità bastano.
-          </p>
-          <h2 className="heading-text text-2xl text-gray-900 mb-2">Cosa vedremo</h2>
-          <ul className="modern-text text-gray-700 list-disc pl-5 mb-6">
-            <li>Basi del prompting e sicurezza</li>
-            <li>Creare un mini-gioco browser con AI</li>
-            <li>Iterare su grafica, controlli e difficoltà</li>
-            <li>Pubblicare un&apos;anteprima giocabile</li>
+        </section>
+
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <h2 className="text-xl font-semibold text-slate-900">Cosa impariamo</h2>
+          <ul className="mt-4 list-disc space-y-3 pl-5 text-base leading-7 text-slate-600">
+            <li>Basi del prompting e pratiche di sicurezza.</li>
+            <li>Creare un mini gioco browser con l’aiuto dell’AI.</li>
+            <li>Iterare su grafica, controlli e difficoltà.</li>
+            <li>Pubblicare un’anteprima giocabile da condividere.</li>
           </ul>
-          <h2 className="heading-text text-2xl text-gray-900 mb-2">Prenota</h2>
-          <p className="modern-text text-gray-700">Scrivi a <a href="mailto:hello@gamesincjr.com" className="underline">hello@gamesincjr.com</a>. Consenso dei genitori richiesto per i minori.</p>
-        </div>
+        </section>
+
+        <section className="rounded-3xl bg-sky-50/70 p-8 shadow-lg ring-1 ring-sky-100">
+          <h2 className="text-xl font-semibold text-slate-900">Prenota una sessione</h2>
+          <p className="mt-4 text-base leading-7 text-slate-600">
+            Scrivi a <a className="font-semibold text-sky-600 underline" href="mailto:hello@gamesincjr.com">hello@gamesincjr.com</a> con gli orari preferiti. Per i minori serve il consenso dei genitori.
+          </p>
+          <p className="mt-3 text-sm text-slate-500">Le sessioni individuali o per piccoli gruppi (fino a 3) hanno lo stesso prezzo.</p>
+        </section>
       </div>
-    </main>
+    </PageShell>
   );
 }
-
-

--- a/src/app/tech/page.tsx
+++ b/src/app/tech/page.tsx
@@ -1,25 +1,38 @@
-export const metadata = { title: 'How the site works • Games Inc Jr' };
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
+
+const points = [
+  "Built with Next.js so most screens render on the server for instant loads.",
+  "Game metadata lives in a tiny JSON file and a helper reads it across the app.",
+  "Playable demos are static HTML/JS bundles inside /public, embedded with sandboxed iframes.",
+  "Community posts go through a simple API backed by Upstash Redis (with an in-memory fallback for local dev).",
+  "Demo login drops cookies for your selected tier today; long term we&apos;ll shift to email magic links and Stripe.",
+  "Security headers and iframe sandboxing keep previews contained.",
+  "Italian and English copy live side by side so localisation is easy to expand.",
+  "Deployments run on Vercel—push to main and the site updates automatically.",
+];
+
+export const metadata = { title: "How the site works • Games Inc Jr" };
 
 export default function TechOverview() {
   return (
-    <main className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-16">
-        <div className="max-w-4xl mx-auto bg-white rounded-2xl p-8 shadow">
-          <h1 className="pixel-text text-4xl text-gray-900 mb-4">How the site works (plain English)</h1>
-          <ol className="list-decimal pl-5 space-y-3 modern-text text-gray-700">
-            <li><strong>Pages</strong>: The site runs on Next.js. Most pages are simple server-rendered React components.</li>
-            <li><strong>Games data</strong>: A small JSON file in the repo lists games. We read it using a tiny TypeScript helper.</li>
-            <li><strong>Playable demos</strong>: Each demo is a normal HTML/JS file in the public folder, embedded with an iframe. No downloads.</li>
-            <li><strong>Community feed</strong>: A small API lets visitors post and read messages. We store them in Upstash (a hosted Redis). If not configured, it stores in memory for dev.</li>
-            <li><strong>Login & tiers</strong>: A minimal demo login sets a cookie for your selected tier. Later we’ll switch to email magic-links and Stripe.</li>
-            <li><strong>Security</strong>: We set basic headers and run demos in a sandboxed iframe.</li>
-            <li><strong>Internationalisation</strong>: English and Italian pages live under different paths. Copy can be translated per page or per game.</li>
-            <li><strong>Deploy</strong>: Pushing to GitHub triggers Vercel to deploy. Some pages bypass caching so new data shows immediately.</li>
+    <PageShell>
+      <div className="mx-auto flex max-w-4xl flex-col gap-12">
+        <PageHeader
+          align="left"
+          eyebrow="Behind the scenes"
+          title="How the site works (plain English)"
+          description="A quick tour of the architecture so families and collaborators know what keeps Games inc. Jr running smoothly."
+        />
+
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <ol className="list-decimal space-y-4 pl-5 text-base leading-7 text-slate-600">
+            {points.map((point) => (
+              <li key={point}>{point}</li>
+            ))}
           </ol>
-        </div>
+        </section>
       </div>
-    </main>
+    </PageShell>
   );
 }
-
-

--- a/src/app/tutorials/page.tsx
+++ b/src/app/tutorials/page.tsx
@@ -1,43 +1,44 @@
-export const metadata = { title: 'Tutorials • Games Inc Jr' };
+import PageHeader from "@/components/PageHeader";
+import PageShell from "@/components/PageShell";
+
+export const metadata = { title: "Tutorials • Games Inc Jr" };
 
 export default function TutorialsPage() {
   return (
-    <main className="min-h-screen gaming-bg pixel-pattern">
-      <div className="container mx-auto px-4 py-16">
-        <div className="max-w-4xl mx-auto bg-white rounded-2xl p-8 shadow">
-          <h1 className="pixel-text text-4xl text-gray-900 mb-4">Coding Tutorials</h1>
-          <p className="modern-text text-gray-700 mb-6">
-            We offer 30‑minute remote sessions at <strong>£25 per student</strong> to show how kids (7+)
-            can get started with AI‑assisted, prompt‑based coding.
-          </p>
+    <PageShell>
+      <div className="mx-auto flex max-w-4xl flex-col gap-12">
+        <PageHeader
+          align="left"
+          eyebrow="30-minute sessions"
+          title="Coding tutorials for curious kids"
+          description="We run focused, remote sessions (£25 per student) that show 7+ learners how to bring ideas to life with AI-assisted, prompt-based workflows."
+        />
 
-          <h2 className="heading-text text-2xl text-gray-900 mb-2">Why now?</h2>
-          <p className="modern-text text-gray-700 mb-6">
-            The industry has changed dramatically with AI. “Vibe coding” — describing what you want in
-            clear language and iterating quickly — is now common at big tech companies and among
-            indie creators. You don’t need prior coding experience: bring a clear vision, communicate
-            well, pay attention to detail, and don’t be afraid of technology. Even kids can bring ideas
-            to life in minutes.
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <h2 className="text-xl font-semibold text-slate-900">Why now?</h2>
+          <p className="mt-4 text-base leading-7 text-slate-600">
+            The industry is shifting fast with AI. Vibe coding—describing what you want clearly and iterating quickly—is now standard. You don&apos;t need prior experience; bring a vision, communicate it, pay attention to detail and embrace the tech.
           </p>
+        </section>
 
-          <h2 className="heading-text text-2xl text-gray-900 mb-2">What we cover</h2>
-          <ul className="modern-text text-gray-700 list-disc pl-5 mb-6">
-            <li>Prompting fundamentals and safe practices</li>
-            <li>Building a tiny browser game with AI assistance</li>
-            <li>Iterating on visuals, controls, and difficulty</li>
-            <li>Publishing a playable preview</li>
+        <section className="rounded-3xl bg-white/80 p-8 shadow-lg ring-1 ring-slate-100">
+          <h2 className="text-xl font-semibold text-slate-900">What we cover</h2>
+          <ul className="mt-4 list-disc space-y-3 pl-5 text-base leading-7 text-slate-600">
+            <li>Prompting fundamentals and how to stay safe.</li>
+            <li>Building a tiny browser game with AI assistance.</li>
+            <li>Iterating on visuals, controls and difficulty.</li>
+            <li>Publishing a playable preview you can share.</li>
           </ul>
+        </section>
 
-          <h2 className="heading-text text-2xl text-gray-900 mb-2">Book a session</h2>
-          <p className="modern-text text-gray-700 mb-2">
-            Email <a href="mailto:hello@gamesincjr.com" className="underline">hello@gamesincjr.com</a>
-            {' '}with preferred times. Parental consent required for under‑16s.
+        <section className="rounded-3xl bg-sky-50/70 p-8 shadow-lg ring-1 ring-sky-100">
+          <h2 className="text-xl font-semibold text-slate-900">Book a session</h2>
+          <p className="mt-4 text-base leading-7 text-slate-600">
+            Email <a className="font-semibold text-sky-600 underline" href="mailto:hello@gamesincjr.com">hello@gamesincjr.com</a> with preferred times. Parental consent is required for under-16s.
           </p>
-          <p className="modern-text text-gray-600 text-sm">One‑to‑one or small groups (up to 3) at the same price.</p>
-        </div>
+          <p className="mt-3 text-sm text-slate-500">One-to-one or small groups (up to three students) cost the same.</p>
+        </section>
       </div>
-    </main>
+    </PageShell>
   );
 }
-
-

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import React from 'react';
 
 interface LogoProps {
@@ -16,14 +17,14 @@ export default function Logo({ className = '', size = 'md' }: LogoProps) {
 
   return (
     <div className={`${sizeClasses[size]} ${className} relative`}>
-      <img
+      <Image
         src="/images/logo.png"
         alt="Games Inc Jr Logo"
-        className="w-full h-full object-contain"
-        onError={(e) => {
-          // Fallback to placeholder if main logo fails to load
-          const target = e.target as HTMLImageElement;
-          target.src = '/images/logo-placeholder.svg';
+        fill
+        sizes="(min-width: 1024px) 8rem, (min-width: 640px) 6rem, 100vw"
+        className="object-contain"
+        onError={(event) => {
+          event.currentTarget.src = '/images/logo-placeholder.svg';
         }}
       />
     </div>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,52 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface PageHeaderProps {
+  /** Optional eyebrow copy rendered above the title */
+  eyebrow?: string;
+  /** Main headline for the page */
+  title: string;
+  /** Supporting copy shown under the title */
+  description?: ReactNode;
+  /** Slot for buttons or links that align next to the copy */
+  actions?: ReactNode;
+  /** Controls text alignment */
+  align?: "left" | "center";
+}
+
+/**
+ * PageHeader keeps hero copy consistent between routes. It optionally renders
+ * an action area so pages can surface secondary buttons without bespoke markup.
+ */
+export default function PageHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  align = "center",
+}: PageHeaderProps) {
+  const alignment = align === "center" ? "items-center text-center" : "items-start text-left";
+
+  return (
+    <header className={cn("flex flex-col gap-6 sm:gap-8", alignment)}>
+      <div className="flex flex-col gap-4">
+        {eyebrow && (
+          <span className="inline-flex items-center justify-center rounded-full bg-white/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-sky-600 shadow-sm ring-1 ring-sky-100">
+            {eyebrow}
+          </span>
+        )}
+        <h1 className="text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl">
+          {title}
+        </h1>
+        {description && (
+          <p className="max-w-3xl text-base leading-7 text-slate-600 sm:text-lg sm:leading-8">
+            {description}
+          </p>
+        )}
+      </div>
+      {actions && (
+        <div className={cn("flex flex-col gap-3 sm:flex-row", align === "center" ? "justify-center" : "justify-start")}>{actions}</div>
+      )}
+    </header>
+  );
+}

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface PageShellProps {
+  /** Optional additional class names applied to the inner container */
+  className?: string;
+  /** Content rendered inside the shell */
+  children: ReactNode;
+  /** Controls how vibrant the gradient background should appear */
+  tone?: "soft" | "vibrant";
+}
+
+/**
+ * PageShell wraps top-level pages in a consistent gradient background and spacing.
+ * It keeps decorative blobs behind the content so every page feels part of the same system.
+ */
+export default function PageShell({
+  className,
+  children,
+  tone = "soft",
+}: PageShellProps) {
+  const background =
+    tone === "vibrant"
+      ? "bg-gradient-to-br from-sky-100 via-white to-rose-100"
+      : "bg-gradient-to-br from-slate-50 via-white to-sky-50";
+
+  return (
+    <main className={cn("relative isolate overflow-hidden", background)}>
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute -top-32 right-1/5 h-80 w-80 rounded-full bg-sky-200/35 blur-3xl" />
+        <div className="absolute bottom-[-6rem] left-1/4 h-96 w-96 rounded-full bg-rose-200/30 blur-3xl" />
+        <div className="absolute top-1/2 left-[-4rem] h-72 w-72 -translate-y-1/2 rounded-full bg-amber-200/25 blur-3xl" />
+      </div>
+      <div className={cn("container mx-auto px-4 py-16 sm:py-20 lg:py-24", className)}>
+        {children}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce reusable PageShell and PageHeader components to share the new gradient background and hero pattern across pages
- restyle English and Italian content pages, the games library, and the game detail views to use the shared design language and optimized Next.js Image components
- refresh the community form with better validation plus translated copy support, update the logo image handling, and clean up legacy CSS utilities

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e567e90f78832d8476dc4eed9ac572