### PR TITLE
Fix account login cookie for local development

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -80,7 +80,14 @@ export default async function AccountPage() {
               }
 
               const jar = await serverCookies();
-              jar.set("gi_user", username, { httpOnly: false, secure: true, sameSite: "lax", path: "/", maxAge: 60 * 60 * 24 * 365 });
+              const isProduction = process.env.NODE_ENV === "production";
+              jar.set("gi_user", username, {
+                httpOnly: false,
+                secure: isProduction,
+                sameSite: "lax",
+                path: "/",
+                maxAge: 60 * 60 * 24 * 365,
+              });
               redirect("/imaginary-friends");
             }}
           >


### PR DESCRIPTION
## Summary
- ensure the account login cookie only sets the secure flag in production so it persists during local development

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ea36662f60832db3e3f4d7bec8c86f