### PR TITLE
Improve Magic AI Friends chat clearing and history deletion

### DIFF
--- a/src/app/tables/practice/PracticeClient.tsx
+++ b/src/app/tables/practice/PracticeClient.tsx
@@ -99,7 +99,7 @@ export function PracticeClient({ sessionId, userId, initialTargets }: Props) {
           message = "Progress saved, but we could not load a new batch. Try again in a moment.";
         } else if (nextBatch.length === 0) {
           message = "Everything due is complete right now. Great job staying on top of your facts!";
-        } else if (data.correct) {
+        } else if (wasCorrect) {
           message = "Batch cleared! A fresh set of practice facts is ready.";
         }
       }

--- a/src/features/imaginary-friends/components/ConversationPanel.tsx
+++ b/src/features/imaginary-friends/components/ConversationPanel.tsx
@@ -10,22 +10,35 @@ interface ConversationPanelProps {
   topics: Topic[];
   onSendMessage: (message: string, requestImage?: boolean) => void;
   onSelectTopic: (topic: Topic) => void;
+  onClearChat?: () => void;
+  onNewThread?: () => void;
+  onDeleteHistory?: () => void;
   isLoading: boolean;
   showImageButton?: boolean;
   sessionInfo?: SessionInfo | null;
   gameStatus?: GameStatus | null;
+  isDeletingHistory?: boolean;
 }
 
+/**
+ * Renders the active conversation view for a selected imaginary friend.
+ * The component receives a filtered list of messages to display so that
+ * callers can hide previous history while keeping it available for context.
+ */
 export default function ConversationPanel({
   messages,
   character,
   topics,
   onSendMessage,
   onSelectTopic,
+  onClearChat,
+  onNewThread,
+  onDeleteHistory,
   isLoading,
   showImageButton = false,
   sessionInfo,
   gameStatus,
+  isDeletingHistory = false,
 }: ConversationPanelProps) {
   const [inputMessage, setInputMessage] = useState('');
   const [showTopics, setShowTopics] = useState(false);
@@ -114,24 +127,31 @@ export default function ConversationPanel({
             type="button"
             onClick={() => {
               setRenderedMessages([]);
-              const ev = new CustomEvent('if:clear-chat');
-              window.dispatchEvent(ev);
+              onClearChat?.();
             }}
-            className="rounded-md border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50"
+            className="rounded-md border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50 disabled:opacity-50"
             title="Clear chat (keeps history saved)"
+            disabled={isLoading}
           >
             Clear chat
           </button>
           <button
             type="button"
-            onClick={() => {
-              const ev = new CustomEvent('if:new-thread');
-              window.dispatchEvent(ev);
-            }}
-            className="rounded-md border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50"
+            onClick={() => onNewThread?.()}
+            className="rounded-md border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50 disabled:opacity-50"
             title="Start a new thread (history retained, context cleared)"
+            disabled={isLoading}
           >
             New thread
+          </button>
+          <button
+            type="button"
+            onClick={() => onDeleteHistory?.()}
+            className="rounded-md border border-rose-200 px-3 py-1.5 text-xs text-rose-600 hover:bg-rose-50 disabled:opacity-50"
+            title="Delete all saved history for this friend"
+            disabled={isLoading || isDeletingHistory}
+          >
+            {isDeletingHistory ? 'Deleting…' : 'Delete history'}
           </button>
         </div>
       </div>

--- a/src/features/imaginary-friends/components/ConversationPanel.tsx
+++ b/src/features/imaginary-friends/components/ConversationPanel.tsx
@@ -44,10 +44,7 @@ export default function ConversationPanel({
   const [showTopics, setShowTopics] = useState(false);
   const [countdown, setCountdown] = useState<number>(0);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
-  const [renderedMessages, setRenderedMessages] = useState(messages);
-
   useEffect(() => {
-    setRenderedMessages(messages);
     requestAnimationFrame(() => {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     });
@@ -125,10 +122,7 @@ export default function ConversationPanel({
         <div className="flex gap-2">
           <button
             type="button"
-            onClick={() => {
-              setRenderedMessages([]);
-              onClearChat?.();
-            }}
+            onClick={() => onClearChat?.()}
             className="rounded-md border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50 disabled:opacity-50"
             title="Clear chat (keeps history saved)"
             disabled={isLoading}
@@ -185,7 +179,7 @@ export default function ConversationPanel({
         </div>
       )}
       <div className="messages-container">
-        {renderedMessages.map((message) => (
+        {messages.map((message) => (
           <div
             key={`${message.id}-${messages.length}`}
             className={`message ${message.speaker === 'player' ? 'player-message' : 'character-message'}`}


### PR DESCRIPTION
## Summary
- preserve cleared chats for context by tracking a hidden cutoff, persisting it with the saved messages payload, and filtering the visible conversation
- add explicit handlers for clearing, starting new threads, and deleting chat history via the API while keeping session storage in sync
- update the conversation panel controls to call the new handlers and expose a delete-history action with appropriate loading states

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ebd815c2d4832da2d3dc8438a32b94