### PR TITLE
Make clear chat delete history and add cleanup tooling

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,81 @@
+# Magic AI Friends Transcript Maintenance Runbook
+
+This runbook documents how to audit, purge, and validate Magic AI Friends chat transcripts across environments. The goal is to ensure that the "Clear chat" action permanently deletes history, prevents stale rehydration, and keeps blob/filesystem storage tidy.
+
+## 1. Inventory and Configuration
+
+1. Inspect the storage mode:
+   ```bash
+   echo "$IMAGINARY_FRIENDS_STORAGE"
+   ```
+   - `filesystem`: transcripts are written under `data/imaginary-friends/conversations/`.
+   - `blob`: transcripts live in Vercel Blob storage.
+   - `auto` (default): filesystem when running locally, blob on Vercel deployments.
+2. Confirm available blob credentials:
+   ```bash
+   env | grep -E 'VERCEL_BLOB_RW_TOKEN|BLOB_READ_WRITE_TOKEN|BLOB_TOKEN'
+   ```
+   Record the token that is active in production so purge scripts can authenticate.
+3. For local/dev machines note the absolute path of the conversation folder. It is resolved from the project root as `./data/imaginary-friends/conversations/`.
+
+## 2. Purging Existing Logs
+
+### Local / Development (filesystem)
+
+Use the bundled cleanup script to remove every per-user transcript file:
+```bash
+pnpm tsx scripts/purge-imaginary-friends-history.ts --mode=filesystem
+```
+- Add `--dry-run` to preview which directories would be deleted.
+- The script deletes the entire `conversations` folder and recreates it on demand.
+
+### Production / Vercel (blob storage)
+
+1. Export a blob RW token in your shell session:
+   ```bash
+   export VERCEL_BLOB_RW_TOKEN="<token from project settings>"
+   ```
+2. Run the purge script in blob mode (you can run this from a local checkout):
+   ```bash
+   pnpm tsx scripts/purge-imaginary-friends-history.ts --mode=blob --dry-run
+   pnpm tsx scripts/purge-imaginary-friends-history.ts --mode=blob
+   ```
+3. The script enumerates every blob under `imaginary-friends/conversations/**` and deletes them. Re-run with `--dry-run` to confirm the list is empty afterwards.
+
+> **Safety tip:** To temporarily pause new logging, set `IMAGINARY_FRIENDS_STORAGE=none`, deploy, run the purge, and then restore the previous value before the final deployment.
+
+## 3. Clear Chat Behaviour
+
+- The "Clear chat" button now issues `DELETE /api/imaginary-friends/history` for the active user + character.
+- While the deletion request is running the button shows a spinner and is disabled (the "New thread" button is also disabled).
+- After the API call succeeds the UI clears local state and records a `sessionStorage` marker so the session will not rehydrate stale turns during the same browsing session.
+- When the user sends a new message the marker is removed, allowing fresh history to hydrate later.
+
+## 4. Preventing Immediate Rehydration
+
+`sessionStorage` keeps a `if_clearedConversations` map keyed by `<userId>::<characterId>`. When present, the UI skips the `/history` fetch so cleared chats never resurface until the user starts a new conversation.
+
+## 5. Validation Checklist
+
+1. Start the dev server (`pnpm dev`) and log in as a test user.
+2. Open a Magic AI Friends chat, send a message, and confirm it appears.
+3. Click **Clear & delete history**. The button should show “Clearing…” briefly and the conversation should empty.
+4. Reload the page — no history should reappear.
+5. Send a new message to the same friend, reload, and verify the fresh chat persists.
+6. Optionally, run the purge script with `--dry-run` to confirm no stray files/blobs remain.
+
+For production rollouts, execute the blob purge on a preview deployment first, then repeat after the production deploy.
+
+## 6. Prisma Engine Warnings (Dev Convenience)
+
+If the Prisma engine checksum warning appears during `pnpm dev`, you can silence it by setting:
+```bash
+export PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1
+```
+Alternatively update Prisma to the latest compatible release before development if preferred.
+
+## 7. References
+
+- Cleanup script: `scripts/purge-imaginary-friends-history.ts`
+- API implementation: `src/app/api/imaginary-friends/_lib/service.ts`
+- Front-end behaviour: `src/features/imaginary-friends/ImaginaryFriendsApp.tsx`

--- a/scripts/purge-imaginary-friends-history.ts
+++ b/scripts/purge-imaginary-friends-history.ts
@@ -1,0 +1,184 @@
+/**
+ * @file Purge Magic AI Friends conversation transcripts across configured storage backends.
+ *
+ * Usage:
+ *   pnpm tsx scripts/purge-imaginary-friends-history.ts [--mode=filesystem|blob|all] [--dry-run]
+ *
+ * Flags:
+ *   --mode       Force a specific backend (filesystem, blob, or all). Auto-detects when omitted.
+ *   --dry-run    Log the files/blobs that would be removed without deleting them.
+ *   --verbose    Print additional diagnostic details.
+ *   --help       Show this help message.
+ *
+ * The script respects IMAGINARY_FRIENDS_STORAGE to guide detection and checks
+ * for VERCEL_BLOB_RW_TOKEN or BLOB_READ_WRITE_TOKEN when targeting blob storage.
+ */
+
+import fs from 'node:fs';
+import { rm, stat } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+type Mode = 'filesystem' | 'blob';
+
+type CliOptions = {
+  dryRun: boolean;
+  verbose: boolean;
+  modes: Mode[];
+};
+
+const CONVERSATIONS_PATH = path.join('data', 'imaginary-friends', 'conversations');
+
+const args = process.argv.slice(2);
+
+function printUsage() {
+  console.info(`\nMagic AI Friends transcript purge utility\n\n` +
+    `Usage:\n  pnpm tsx scripts/purge-imaginary-friends-history.ts [options]\n\n` +
+    `Options:\n  --mode=filesystem|blob|all  Select the storage backend to purge.\n` +
+    `  --dry-run                 Preview actions without deleting data.\n` +
+    `  --verbose                Print additional diagnostic output.\n` +
+    `  --help                   Show this message.\n`);
+}
+
+if (args.includes('--help')) {
+  printUsage();
+  process.exit(0);
+}
+
+function resolveModes(): Mode[] {
+  const modeArg = args.find((arg) => arg.startsWith('--mode='));
+  if (modeArg) {
+    const value = modeArg.split('=')[1];
+    if (value === 'all') return ['filesystem', 'blob'];
+    if (value === 'filesystem' || value === 'blob') return [value];
+    throw new Error(`Unsupported mode "${value}". Use filesystem, blob, or all.`);
+  }
+
+  const inferred: Set<Mode> = new Set();
+  const storageMode = (process.env.IMAGINARY_FRIENDS_STORAGE ?? 'auto').toLowerCase();
+  const rootPath = process.cwd();
+  const localPath = path.join(rootPath, CONVERSATIONS_PATH);
+
+  if (storageMode === 'filesystem' || storageMode === 'auto') {
+    if (fs.existsSync(localPath)) {
+      inferred.add('filesystem');
+    }
+  }
+
+  const blobToken =
+    process.env.VERCEL_BLOB_RW_TOKEN ?? process.env.BLOB_READ_WRITE_TOKEN ?? process.env.BLOB_TOKEN;
+  if ((storageMode === 'blob' || storageMode === 'auto') && blobToken) {
+    inferred.add('blob');
+  }
+
+  return Array.from(inferred);
+}
+
+function parseCliOptions(): CliOptions {
+  const dryRun = args.includes('--dry-run');
+  const verbose = args.includes('--verbose');
+  const modes = resolveModes();
+  return { dryRun, verbose, modes };
+}
+
+async function purgeFilesystem({ dryRun, verbose }: CliOptions) {
+  const target = path.join(process.cwd(), CONVERSATIONS_PATH);
+  try {
+    await stat(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      if (verbose) {
+        console.info(`[filesystem] No local transcripts found at ${target}`);
+      }
+      return;
+    }
+    throw error;
+  }
+
+  if (dryRun) {
+    console.info(`[filesystem] Dry run: would remove ${target}`);
+    return;
+  }
+
+  await rm(target, { recursive: true, force: true });
+  console.info(`[filesystem] Removed ${target}`);
+}
+
+async function collectBlobs(token: string) {
+  const { list } = await import('@vercel/blob');
+  const prefix = 'imaginary-friends/conversations/';
+  const all: Array<{ pathname: string }> = [];
+  let cursor: string | undefined;
+  do {
+    const response = await list({ prefix, token, cursor });
+    all.push(...response.blobs.map((blob) => ({ pathname: blob.pathname })));
+    cursor = response.cursor ?? undefined;
+  } while (cursor);
+  return all;
+}
+
+async function purgeBlob({ dryRun, verbose }: CliOptions) {
+  const token =
+    process.env.VERCEL_BLOB_RW_TOKEN ?? process.env.BLOB_READ_WRITE_TOKEN ?? process.env.BLOB_TOKEN;
+  if (!token) {
+    throw new Error('Blob mode requested but no Vercel blob RW token found in the environment.');
+  }
+
+  const blobs = await collectBlobs(token);
+  if (!blobs.length) {
+    if (verbose) {
+      console.info('[blob] No blob transcripts found for imaginary-friends/conversations/.');
+    }
+    return;
+  }
+
+  if (dryRun) {
+    console.info(`[blob] Dry run: would delete ${blobs.length} blob(s).`);
+    blobs.slice(0, 10).forEach((blob) => console.info(`  - ${blob.pathname}`));
+    if (blobs.length > 10) console.info('  ...');
+    return;
+  }
+
+  const { del } = await import('@vercel/blob');
+  let failureCount = 0;
+  await Promise.all(
+    blobs.map((blob) =>
+      del(blob.pathname, { token }).catch((error: unknown) => {
+        failureCount += 1;
+        if (verbose) {
+          console.warn(`[blob] Failed to delete ${blob.pathname}:`, error);
+        }
+      }),
+    ),
+  );
+
+  const successCount = blobs.length - failureCount;
+  console.info(`[blob] Deleted ${successCount} blob(s).`);
+  if (failureCount > 0) {
+    console.warn(`[blob] ${failureCount} blob(s) could not be removed. Inspect logs above for details.`);
+  }
+}
+
+async function main() {
+  try {
+    const options = parseCliOptions();
+    if (options.modes.length === 0) {
+      console.info('No storage backends detected. Use --mode to force a specific target.');
+      return;
+    }
+
+    for (const mode of options.modes) {
+      if (mode === 'filesystem') {
+        await purgeFilesystem(options);
+      } else if (mode === 'blob') {
+        await purgeBlob(options);
+      }
+    }
+    console.info('Purge complete.');
+  } catch (error) {
+    console.error('Failed to purge Magic AI Friends transcripts:', error);
+    process.exitCode = 1;
+  }
+}
+
+void main();

--- a/src/features/imaginary-friends/components/ConversationPanel.tsx
+++ b/src/features/imaginary-friends/components/ConversationPanel.tsx
@@ -10,14 +10,13 @@ interface ConversationPanelProps {
   topics: Topic[];
   onSendMessage: (message: string, requestImage?: boolean) => void;
   onSelectTopic: (topic: Topic) => void;
-  onClearChat?: () => void;
+  onClearChat?: () => Promise<void> | void;
   onNewThread?: () => void;
-  onDeleteHistory?: () => void;
   isLoading: boolean;
   showImageButton?: boolean;
   sessionInfo?: SessionInfo | null;
   gameStatus?: GameStatus | null;
-  isDeletingHistory?: boolean;
+  isClearingChat?: boolean;
 }
 
 /**
@@ -33,12 +32,11 @@ export default function ConversationPanel({
   onSelectTopic,
   onClearChat,
   onNewThread,
-  onDeleteHistory,
   isLoading,
   showImageButton = false,
   sessionInfo,
   gameStatus,
-  isDeletingHistory = false,
+  isClearingChat = false,
 }: ConversationPanelProps) {
   const [inputMessage, setInputMessage] = useState('');
   const [showTopics, setShowTopics] = useState(false);
@@ -122,30 +120,28 @@ export default function ConversationPanel({
         <div className="flex gap-2">
           <button
             type="button"
-            onClick={() => onClearChat?.()}
+            onClick={() => void onClearChat?.()}
             className="rounded-md border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50 disabled:opacity-50"
-            title="Clear chat (keeps history saved)"
-            disabled={isLoading}
+            title="Clear & delete chat history"
+            disabled={isLoading || isClearingChat}
           >
-            Clear chat
+            {isClearingChat ? (
+              <span className="flex items-center gap-2" aria-live="polite">
+                <span className="h-3 w-3 animate-spin rounded-full border border-slate-400 border-t-transparent" aria-hidden />
+                Clearing…
+              </span>
+            ) : (
+              'Clear & delete history'
+            )}
           </button>
           <button
             type="button"
             onClick={() => onNewThread?.()}
             className="rounded-md border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50 disabled:opacity-50"
             title="Start a new thread (history retained, context cleared)"
-            disabled={isLoading}
+            disabled={isLoading || isClearingChat}
           >
             New thread
-          </button>
-          <button
-            type="button"
-            onClick={() => onDeleteHistory?.()}
-            className="rounded-md border border-rose-200 px-3 py-1.5 text-xs text-rose-600 hover:bg-rose-50 disabled:opacity-50"
-            title="Delete all saved history for this friend"
-            disabled={isLoading || isDeletingHistory}
-          >
-            {isDeletingHistory ? 'Deleting…' : 'Delete history'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update the Magic AI Friends UI so Clear chat deletes history server-side, records per-session clear markers, and prevents immediate rehydration
- refresh the conversation panel controls to show a spinner/disabled state while clearing and remove the redundant Delete history button
- add a reusable purge script plus a runbook documenting storage configuration and cleanup procedures

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ec07592d34832daa0961531be094fa