### PR TITLE
Rename Times Tables mode and add Enter key submissions

### DIFF
--- a/src/app/tables/boss/page.tsx
+++ b/src/app/tables/boss/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import type { KeyboardEvent } from "react";
 
 type Target = { id: string; a: number; b: number; op: "*" };
 
@@ -33,6 +34,14 @@ export default function BossPage() {
     setInput("");
   }
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    // Support quick attacks via Enter without requiring a mouse click.
+    if (event.key === "Enter") {
+      event.preventDefault();
+      void submit();
+    }
+  };
+
   return (
     <div className="mx-auto max-w-md px-4 py-8">
       <h1 className="text-xl font-semibold">Boss Battle</h1>
@@ -41,7 +50,7 @@ export default function BossPage() {
         <div className="mt-6">
           <div className="text-3xl font-bold">{current.a} × {current.b} = ?</div>
           <div className="mt-4 flex gap-2">
-            <input className="w-32 rounded border px-3 py-2" value={input} onChange={e => setInput(e.target.value)} inputMode="numeric" aria-label="Answer" />
+            <input className="w-32 rounded border px-3 py-2" value={input} onChange={e => setInput(e.target.value)} onKeyDown={handleKeyDown} inputMode="numeric" aria-label="Answer" />
             <button className="rounded bg-black px-3 py-2 text-white" onClick={submit}>Attack</button>
           </div>
         </div>

--- a/src/app/tables/challenge/page.tsx
+++ b/src/app/tables/challenge/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import type { KeyboardEvent } from "react";
 
 type Target = { id: string; a: number; b: number; op: "*" };
 
@@ -44,6 +45,14 @@ export default function ChallengePage() {
 
   const accuracy = total ? Math.round((correctCount / total) * 100) : 0;
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    // Mirror the submit button for Enter key presses to speed up play.
+    if (event.key === "Enter") {
+      event.preventDefault();
+      void submit();
+    }
+  };
+
   return (
     <div className="mx-auto max-w-md px-4 py-8">
       <h1 className="text-xl font-semibold">Challenge</h1>
@@ -52,7 +61,7 @@ export default function ChallengePage() {
         <div className="mt-6">
           <div className="text-3xl font-bold">{current.a} × {current.b} = ?</div>
           <div className="mt-4 flex gap-2">
-            <input className="w-32 rounded border px-3 py-2" value={input} onChange={e => setInput(e.target.value)} inputMode="numeric" aria-label="Answer" />
+            <input className="w-32 rounded border px-3 py-2" value={input} onChange={e => setInput(e.target.value)} onKeyDown={handleKeyDown} inputMode="numeric" aria-label="Answer" />
             <button className="rounded bg-black px-3 py-2 text-white" onClick={submit}>Submit</button>
           </div>
         </div>

--- a/src/app/tables/page.tsx
+++ b/src/app/tables/page.tsx
@@ -3,7 +3,7 @@ export const revalidate = 0;
 export default function TablesHome() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-8">
-      <h1 className="text-2xl font-semibold">Times Tables Super Stars ✨</h1>
+      <h1 className="text-2xl font-semibold">Times Tables Mega Stars ✨</h1>
       <p className="mt-2 text-sm text-muted-foreground">Master 1×1–12×12 with points, badges and boss battles. No downloads.</p>
       <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
         <a className="rounded-md border p-4 hover:bg-accent" href="/tables/practice">Practice</a>

--- a/src/app/tables/practice/PracticeClient.tsx
+++ b/src/app/tables/practice/PracticeClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState, useTransition } from "react";
+import type { KeyboardEvent } from "react";
 import { deterministicHint } from "@/lib/tables/core/hints";
 
 type Target = { id: string; a: number; b: number; op: "*" };
@@ -129,6 +130,19 @@ export function PracticeClient({ sessionId, userId, initialTargets }: Props) {
     });
   }, [current, userId]);
 
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      // Allow Enter key presses to submit answers without clicking the button.
+      if (event.key === "Enter") {
+        event.preventDefault();
+        if (!isPending) {
+          submit();
+        }
+      }
+    },
+    [isPending, submit]
+  );
+
   if (!current) {
     return (
       <div className="rounded-2xl border border-dashed border-muted-foreground/40 px-6 py-12 text-center">
@@ -155,6 +169,7 @@ export function PracticeClient({ sessionId, userId, initialTargets }: Props) {
         <input
           value={input}
           onChange={(event) => setInput(event.target.value)}
+          onKeyDown={handleKeyDown}
           className="w-32 rounded-xl border border-border bg-background px-4 py-3 text-lg shadow-inner focus:border-primary focus:outline-none"
           inputMode="numeric"
           disabled={isPending}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,7 +11,7 @@ export default async function Header() {
   const navLinks = [
     { href: '/', label: 'Home' },
     { href: '/games', label: 'Games' },
-    { href: '/tables', label: 'Times Tables Super Stars' },
+    { href: '/tables', label: 'Times Tables Mega Stars' },
     { href: '/community', label: 'Community' },
     { href: '/tutorials', label: 'Tutorials' },
     { href: '/imaginary-friends', label: 'Magic AI Friends' },

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -67,7 +67,7 @@ export default function MobileNav() {
             Games
           </Link>
           <Link href="/tables" className="rounded-xl px-3 py-3 text-slate-600 transition hover:bg-sky-50 hover:text-sky-600" onClick={() => setOpen(false)}>
-            Times Tables Super Stars
+            Times Tables Mega Stars
           </Link>
           <Link href="/community" className="rounded-xl px-3 py-3 text-slate-600 transition hover:bg-sky-50 hover:text-sky-600" onClick={() => setOpen(false)}>
             Community


### PR DESCRIPTION
## Summary
- rename the Times Tables experience to "Times Tables Mega Stars" across navigation and landing content
- allow Enter key presses to submit answers in practice, challenge, and boss modes for faster play

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f34f1ada7c832db34b98f05340f27c