### PR TITLE
Use AI-generated challenge prompts and retry missed facts

### DIFF
--- a/src/app/api/tables/challenge/questions/route.ts
+++ b/src/app/api/tables/challenge/questions/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createSessionWithTargets } from '@/lib/tables/service';
+import { DEFAULT_USER_ID } from '@/lib/tables/constants';
+import { generateChallengeQuestions } from '@/lib/tables/ai/challenge';
+
+export const runtime = 'nodejs';
+
+type ChallengeRequest = {
+  userId?: string;
+  batchSize?: number;
+};
+
+function normaliseBatchSize(size: unknown): number {
+  const value = Number(size);
+  if (!Number.isFinite(value)) return 10;
+  return Math.min(20, Math.max(5, Math.round(value)));
+}
+
+export async function POST(req: NextRequest) {
+  const body = (await req.json().catch(() => ({}))) as ChallengeRequest | undefined;
+  const userId = body?.userId?.trim() || DEFAULT_USER_ID;
+  const batchSize = normaliseBatchSize(body?.batchSize);
+
+  const { session, targets } = await createSessionWithTargets({
+    userId,
+    mode: 'CHALLENGE',
+    batchSize,
+  });
+
+  const questions = await generateChallengeQuestions(targets);
+
+  return NextResponse.json({
+    sessionId: session.id,
+    userId,
+    questions,
+  });
+}

--- a/src/app/tables/challenge/page.tsx
+++ b/src/app/tables/challenge/page.tsx
@@ -1,79 +1,246 @@
 "use client";
-import { useEffect, useState } from "react";
-import type { KeyboardEvent } from "react";
 
-type Target = { id: string; a: number; b: number; op: "*" };
+import { useEffect, useMemo, useState } from "react";
+import type { KeyboardEvent } from "react";
+import type { ChallengeQuestion } from "@/lib/tables/ai/challenge";
+
+type AttemptResponse = {
+  correct: boolean;
+  expected: number;
+  awarded: number;
+};
+
+type ChallengeSession = {
+  sessionId: string;
+  questions: ChallengeQuestion[];
+};
 
 export default function ChallengePage() {
-  const [targets, setTargets] = useState<Target[]>([]);
-  const [current, setCurrent] = useState<Target | null>(null);
-  const [input, setInput] = useState<string>("");
   const [sessionId, setSessionId] = useState<string>("");
+  const [queue, setQueue] = useState<ChallengeQuestion[]>([]);
+  const [reserved, setReserved] = useState<ChallengeQuestion[]>([]);
+  const [allQuestions, setAllQuestions] = useState<ChallengeQuestion[]>([]);
+  const [input, setInput] = useState<string>("");
   const [remaining, setRemaining] = useState<number>(60);
   const [correctCount, setCorrectCount] = useState<number>(0);
+  const [totalAttempts, setTotalAttempts] = useState<number>(0);
   const [coins, setCoins] = useState<number>(0);
-  const [total, setTotal] = useState<number>(0);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [wrongFacts, setWrongFacts] = useState<Record<string, number>>({});
+  const [solvedFacts, setSolvedFacts] = useState<Record<string, boolean>>({});
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const current = queue.length > 0 ? queue[0] : null;
+  const trickyCount = reserved.length;
+  const totalFacts = allQuestions.length;
+  const solvedCount = useMemo(() => Object.keys(solvedFacts).length, [solvedFacts]);
+  const accuracy = totalAttempts ? Math.round((correctCount / totalAttempts) * 100) : 0;
+  const allCleared = !isLoading && remaining > 0 && !current && trickyCount === 0;
 
   useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
     (async () => {
-      const res = await fetch("/api/tables/session", { method: "POST", body: JSON.stringify({ mode: "CHALLENGE" }) });
-      const data = await res.json();
-      setSessionId(data.sessionId);
-      setTargets(data.targets);
-      setCurrent(data.targets[0] || null);
+      try {
+        const res = await fetch("/api/tables/challenge/questions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        });
+        if (!res.ok) {
+          throw new Error("Could not load challenge questions");
+        }
+        const data = (await res.json()) as ChallengeSession;
+        if (cancelled) return;
+        setSessionId(data.sessionId);
+        setQueue(data.questions);
+        setAllQuestions(data.questions);
+        setReserved([]);
+        setFeedback(null);
+        setWrongFacts({});
+        setSolvedFacts({});
+        setRemaining(60);
+        setCorrectCount(0);
+        setTotalAttempts(0);
+        setCoins(0);
+      } catch (cause) {
+        if (cancelled) return;
+        setError(cause instanceof Error ? cause.message : "Failed to load challenge questions");
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
-    const id = setInterval(() => setRemaining((t) => (t > 0 ? t - 1 : 0)), 1000);
+    if (isLoading || remaining <= 0) return;
+    if (queue.length === 0 && reserved.length > 0) {
+      setQueue(reserved);
+      setReserved([]);
+      setFeedback((prev) => prev ?? "Let’s retry the tricky ones!");
+    }
+  }, [isLoading, queue, reserved, remaining]);
+
+  useEffect(() => {
+    if (remaining <= 0) return undefined;
+    const id = setInterval(() => setRemaining((time) => (time > 0 ? time - 1 : 0)), 1000);
     return () => clearInterval(id);
-  }, []);
-
-  async function submit() {
-    if (!current || remaining === 0) return;
-    const answer = Number(input);
-    const res = await fetch("/api/tables/attempt", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ sessionId, factId: current.id, a: current.a, b: current.b, answer, latencyMs: 0, hintUsed: false }) });
-    const data = await res.json();
-    if (typeof data.awarded === 'number') setCoins((c) => c + data.awarded);
-    setTotal((t) => t + 1);
-    if (data.correct) setCorrectCount((c) => c + 1);
-    const idx = targets.findIndex(t => t.id === current.id);
-    const next = targets[idx + 1] || targets[0] || null;
-    setCurrent(next);
-    setInput("");
-  }
-
-  const accuracy = total ? Math.round((correctCount / total) * 100) : 0;
+  }, [remaining]);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    // Mirror the submit button for Enter key presses to speed up play.
     if (event.key === "Enter") {
       event.preventDefault();
       void submit();
     }
   };
 
+  async function submit() {
+    if (!current || remaining === 0 || isSubmitting) return;
+    const trimmed = input.trim();
+    if (!trimmed) {
+      setFeedback("Type your answer to continue.");
+      return;
+    }
+    const answer = Number(trimmed);
+    if (!Number.isFinite(answer)) {
+      setFeedback("Please enter a valid number.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch("/api/tables/attempt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId,
+          factId: current.factId,
+          a: current.a,
+          b: current.b,
+          answer,
+          latencyMs: 0,
+          hintUsed: false,
+        }),
+      });
+      if (!res.ok) {
+        throw new Error("We could not save that answer. Please try again.");
+      }
+      const data = (await res.json()) as AttemptResponse | { error?: string };
+      if ("error" in data) {
+        throw new Error(data.error ?? "Something went wrong.");
+      }
+
+      const wasCorrect = (data as AttemptResponse).correct === true;
+      const expected = (data as AttemptResponse).expected ?? current.answer;
+      if (typeof (data as AttemptResponse).awarded === "number") {
+        setCoins((c) => c + (data as AttemptResponse).awarded);
+      }
+      setTotalAttempts((t) => t + 1);
+      if (wasCorrect) {
+        setCorrectCount((count) => count + 1);
+        setSolvedFacts((prev) => ({ ...prev, [current.factId]: true }));
+        setFeedback("Brilliant! Keep going.");
+      } else {
+        setFeedback(`Almost! ${current.a} × ${current.b} = ${expected}. We’ll revisit it soon.`);
+        setWrongFacts((prev) => ({ ...prev, [current.factId]: (prev[current.factId] ?? 0) + 1 }));
+        setReserved((prev) => {
+          if (prev.some((item) => item.factId === current.factId)) return prev;
+          return [...prev, current];
+        });
+      }
+      setQueue((prev) => prev.slice(1));
+      setInput("");
+    } catch (cause) {
+      setFeedback(cause instanceof Error ? cause.message : "We hit a snag saving that answer. Try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-md px-4 py-8">
+        <h1 className="text-xl font-semibold">Challenge</h1>
+        <p className="mt-4 text-sm text-muted-foreground">Loading questions…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-md px-4 py-8">
+        <h1 className="text-xl font-semibold">Challenge</h1>
+        <p className="mt-4 text-sm text-red-600">{error}</p>
+      </div>
+    );
+  }
+
   return (
     <div className="mx-auto max-w-md px-4 py-8">
       <h1 className="text-xl font-semibold">Challenge</h1>
-      <div className="mt-2 text-sm text-muted-foreground">Time left: {remaining}s — Accuracy: {accuracy}% — Coins: <span className="font-semibold">{coins}</span></div>
+      <div className="mt-2 text-sm text-muted-foreground">
+        Time left: {remaining}s — Accuracy: {accuracy}% — Coins: <span className="font-semibold">{coins}</span>
+      </div>
+      <div className="mt-1 text-xs text-muted-foreground">
+        Solved {solvedCount} of {totalFacts}
+        {trickyCount > 0 ? ` — Tricky facts waiting: ${trickyCount}` : ""}
+      </div>
       {remaining > 0 && current ? (
         <div className="mt-6">
-          <div className="text-3xl font-bold">{current.a} × {current.b} = ?</div>
+          <div className="text-3xl font-bold">{current.prompt}</div>
           <div className="mt-4 flex gap-2">
-            <input className="w-32 rounded border px-3 py-2" value={input} onChange={e => setInput(e.target.value)} onKeyDown={handleKeyDown} inputMode="numeric" aria-label="Answer" />
-            <button className="rounded bg-black px-3 py-2 text-white" onClick={submit}>Submit</button>
+            <input
+              className="w-32 rounded border px-3 py-2"
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={handleKeyDown}
+              inputMode="numeric"
+              aria-label="Answer"
+              disabled={isSubmitting}
+            />
+            <button className="rounded bg-black px-3 py-2 text-white disabled:opacity-60" onClick={submit} disabled={isSubmitting}>
+              Submit
+            </button>
           </div>
+          {feedback && <p className="mt-4 text-sm text-muted-foreground" aria-live="polite">{feedback}</p>}
         </div>
       ) : (
-        <div className="mt-6">
-          <p className="text-sm">Time! Great effort.</p>
+        <div className="mt-6 space-y-4">
+          <p className="text-sm font-medium">
+            {remaining === 0
+              ? "Time! Fantastic effort—check out the questions to review."
+              : allCleared
+                ? "You cleared every fact in this run. Stellar work!"
+                : "Challenge complete. Review the facts below."}
+          </p>
+          {Object.keys(wrongFacts).length > 0 ? (
+            <div className="rounded-lg border border-border bg-card p-4 text-sm">
+              <h2 className="font-semibold">Facts to review</h2>
+              <ul className="mt-2 space-y-1">
+                {Object.entries(wrongFacts).map(([factId, attempts]) => {
+                  const fact = allQuestions.find((item) => item.factId === factId);
+                  if (!fact) return null;
+                  return (
+                    <li key={factId}>
+                      {fact.a} × {fact.b} — needed {attempts + 1} tries
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No tricky facts left—amazing accuracy!</p>
+          )}
         </div>
       )}
     </div>
   );
 }
-
- 
-
-

--- a/src/lib/tables/ai/challenge.ts
+++ b/src/lib/tables/ai/challenge.ts
@@ -1,0 +1,145 @@
+import OpenAI from 'openai';
+import type { SessionTarget } from '@/lib/tables/service';
+import { isAIEnabled } from './featureFlags';
+import { getAIUserFromCookies } from './user';
+
+export type ChallengeQuestion = {
+  factId: string;
+  a: number;
+  b: number;
+  prompt: string;
+  answer: number;
+};
+
+const MODEL = process.env.AI_MODEL_CHALLENGE || process.env.AI_MODEL_CONTENT || 'gpt-4o-mini';
+const SAFE_MODE = process.env.AI_SAFE_MODE !== 'false';
+
+function shuffle<T>(items: T[]): T[] {
+  const clone = [...items];
+  for (let index = clone.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(Math.random() * (index + 1));
+    [clone[index], clone[swapIndex]] = [clone[swapIndex], clone[index]];
+  }
+  return clone;
+}
+
+function buildFallback(targets: SessionTarget[]): ChallengeQuestion[] {
+  return shuffle(targets).map((target) => ({
+    factId: target.id,
+    a: target.a,
+    b: target.b,
+    prompt: `What is ${target.a} × ${target.b}?`,
+    answer: target.a * target.b,
+  }));
+}
+
+export async function generateChallengeQuestions(targets: SessionTarget[]): Promise<ChallengeQuestion[]> {
+  if (targets.length === 0) return [];
+
+  const fallback = buildFallback(targets);
+  const apiKey = process.env.OPENAI_API_KEY;
+
+  try {
+    const user = await getAIUserFromCookies();
+    const aiAllowed = await isAIEnabled(user);
+    if (!aiAllowed || !apiKey) {
+      return fallback;
+    }
+  } catch {
+    return fallback;
+  }
+
+  const client = new OpenAI({ apiKey });
+
+  const factMap = new Map(targets.map((target) => [target.id, target]));
+  const systemPrompt =
+    'You create lively multiplication quiz questions for 7-10 year olds. Keep questions short (<90 chars), upbeat, and only use the provided facts. Return JSON only.';
+  const factList = targets
+    .map((target) => `${target.id}:${target.a}x${target.b}`)
+    .join(', ');
+
+  try {
+    const response = await client.responses.create({
+      model: MODEL,
+      input: [
+        { role: 'system', content: systemPrompt },
+        {
+          role: 'user',
+          content: `Facts: ${factList}\nReturn JSON {"questions":[{"factId":"id","prompt":"text","answer":number}]}. Ensure answer = a*b and prompt references multiplication.`,
+        },
+      ],
+      ...(SAFE_MODE
+        ? {
+            response_format: {
+              type: 'json_schema',
+              json_schema: {
+                name: 'ChallengeQuestions',
+                schema: {
+                  type: 'object',
+                  properties: {
+                    questions: {
+                      type: 'array',
+                      minItems: targets.length,
+                      maxItems: targets.length,
+                      items: {
+                        type: 'object',
+                        properties: {
+                          factId: { type: 'string' },
+                          prompt: { type: 'string', maxLength: 120 },
+                          answer: { type: 'integer' },
+                        },
+                        required: ['factId', 'prompt', 'answer'],
+                        additionalProperties: false,
+                      },
+                    },
+                  },
+                  required: ['questions'],
+                  additionalProperties: false,
+                },
+              },
+            },
+          }
+        : {}),
+      max_output_tokens: 400,
+      temperature: 0.6,
+    });
+
+    const text = response.output_text;
+    if (!text) {
+      return fallback;
+    }
+
+    const parsed = JSON.parse(text) as { questions?: Array<{ factId?: string; prompt?: string; answer?: number }> };
+    const used = new Set<string>();
+    const enriched: ChallengeQuestion[] = [];
+
+    for (const entry of parsed.questions ?? []) {
+      if (!entry || typeof entry !== 'object') continue;
+      const factId = typeof entry.factId === 'string' ? entry.factId.trim() : '';
+      if (!factId || used.has(factId)) continue;
+      const target = factMap.get(factId);
+      if (!target) continue;
+      const prompt = typeof entry.prompt === 'string' ? entry.prompt.trim() : '';
+      if (!prompt) continue;
+      const answer = Number(entry.answer);
+      if (!Number.isFinite(answer) || answer !== target.a * target.b) continue;
+      used.add(factId);
+      enriched.push({
+        factId,
+        a: target.a,
+        b: target.b,
+        prompt: prompt.slice(0, 120),
+        answer: target.a * target.b,
+      });
+    }
+
+    if (enriched.length === targets.length) {
+      return enriched;
+    }
+
+    const remaining = fallback.filter((item) => !used.has(item.factId));
+    return [...enriched, ...remaining];
+  } catch {
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary
- add an AI-backed challenge question generator that enriches scheduler targets with creative prompts
- update the challenge UI to load the new questions, track missed facts, and recycle them until solved
- reset challenge session stats and surface a review summary for any tricky facts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f353762f94832d8ee9eb26ffb85cbe