### PR TITLE
Fix Frog Fly Feast state initialization

### DIFF
--- a/public/demos/frog-fly-feast/index.html
+++ b/public/demos/frog-fly-feast/index.html
@@ -1,0 +1,724 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Frog Fly Feast - Demo</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: 'Nunito', 'Segoe UI', Tahoma, sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 16px;
+      padding: 32px 16px 64px;
+      background: radial-gradient(circle at top, #0f172a 0%, #020617 70%, #01040a 100%);
+      color: #e0f2fe;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(2.4rem, 5vw, 3.6rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #bef264;
+      text-shadow: 0 10px 32px rgba(132, 204, 22, 0.35);
+    }
+
+    .tagline {
+      margin: 0;
+      font-size: clamp(1rem, 2.5vw, 1.4rem);
+      color: #bae6fd;
+      text-align: center;
+      max-width: 760px;
+    }
+
+    .hud {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: clamp(16px, 4vw, 32px);
+      font-size: clamp(1.1rem, 2.4vw, 1.5rem);
+      font-weight: 700;
+    }
+
+    .hud span {
+      color: #fef08a;
+      margin-left: 6px;
+    }
+
+    .stage {
+      position: relative;
+      width: min(92vw, 880px);
+      aspect-ratio: 4 / 3;
+      border-radius: 28px;
+      overflow: hidden;
+      border: 2px solid rgba(190, 242, 100, 0.45);
+      box-shadow: 0 28px 68px rgba(5, 12, 24, 0.7);
+      background: linear-gradient(180deg, rgba(15, 23, 42, 0.85), rgba(2, 6, 23, 0.95));
+      backdrop-filter: blur(6px);
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: 100%;
+      touch-action: none;
+    }
+
+    .status {
+      font-size: 1rem;
+      text-align: center;
+      color: #cbd5f5;
+      max-width: 720px;
+      line-height: 1.6;
+    }
+
+    .status strong { color: #fef08a; }
+
+    .overlay {
+      position: absolute;
+      inset: 0;
+      background: rgba(4, 7, 19, 0.88);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 20px;
+      padding: 24px;
+      text-align: center;
+      transition: opacity 0.25s ease;
+    }
+
+    .overlay.hidden {
+      pointer-events: none;
+      opacity: 0;
+    }
+
+    .overlay h2 {
+      margin: 0;
+      font-size: clamp(2rem, 4vw, 2.6rem);
+      color: #bef264;
+    }
+
+    .overlay p {
+      margin: 0;
+      color: #e0f2fe;
+      line-height: 1.6;
+    }
+
+    .overlay button {
+      padding: 14px 28px;
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #04121a;
+      background: linear-gradient(135deg, #bef264 0%, #65a30d 100%);
+      border: none;
+      border-radius: 999px;
+      cursor: pointer;
+      box-shadow: 0 16px 40px rgba(101, 163, 13, 0.4);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .overlay button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 20px 52px rgba(101, 163, 13, 0.55);
+    }
+
+    .overlay button:focus-visible {
+      outline: 3px solid rgba(190, 242, 100, 0.8);
+      outline-offset: 2px;
+    }
+
+    .controls {
+      display: none;
+      gap: 12px;
+      padding: 14px 18px;
+      border-radius: 18px;
+      background: rgba(2, 6, 23, 0.75);
+      border: 1px solid rgba(190, 242, 100, 0.35);
+      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
+      backdrop-filter: blur(12px);
+      position: fixed;
+      bottom: 24px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 10;
+    }
+
+    .controls button {
+      width: 56px;
+      height: 56px;
+      border-radius: 16px;
+      border: 1px solid rgba(190, 242, 100, 0.4);
+      background: rgba(5, 12, 24, 0.8);
+      color: #bef264;
+      font-size: 1.3rem;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .controls button:active {
+      transform: scale(0.96);
+      background: rgba(65, 130, 17, 0.8);
+      color: #fefce8;
+    }
+
+    @media (max-width: 900px) {
+      .controls { display: flex; }
+    }
+  </style>
+</head>
+<body>
+  <h1>Frog Fly Feast</h1>
+  <p class="tagline">Leap between lily pads, dodge prowling snakes, and snap up glowing flies before they flutter away.</p>
+
+  <div class="hud" role="status" aria-live="polite">
+    <div>Score:<span id="score">0</span></div>
+    <div>Flies caught:<span id="flies">0</span></div>
+    <div>Lives:<span id="lives">3</span></div>
+  </div>
+
+  <div class="stage">
+    <canvas id="game" width="800" height="600" aria-label="Frog dodging snakes and catching flies"></canvas>
+    <div id="overlay" class="overlay" role="dialog" aria-modal="true">
+      <h2>Ready to Hop?</h2>
+      <p data-overlay-main>Use the arrow keys (or the green controls) to hop to neighbouring lily pads. Wait for the gap, dodge the snakes, and reach flies before they blink out.</p>
+      <p data-overlay-detail>Catch <strong>five</strong> flies in a row to earn a bonus streak!</p>
+      <button id="start">Start hopping</button>
+    </div>
+  </div>
+
+  <p class="status">Tip: jumps take a heartbeat. Line up the timing so the snakes glide past <strong>before</strong> you land, then grab the fly while it&apos;s still glowing.</p>
+
+  <div class="controls" aria-hidden="true">
+    <button data-move="up" aria-label="Move up">▲</button>
+    <div style="display:flex; gap:12px;">
+      <button data-move="left" aria-label="Move left">◄</button>
+      <button data-move="down" aria-label="Move down">▼</button>
+      <button data-move="right" aria-label="Move right">►</button>
+    </div>
+  </div>
+
+  <script type="module">
+    const canvas = document.getElementById('game');
+    const ctx = canvas.getContext('2d');
+    const overlay = document.getElementById('overlay');
+    const startButton = document.getElementById('start');
+    const scoreEl = document.getElementById('score');
+    const fliesEl = document.getElementById('flies');
+    const livesEl = document.getElementById('lives');
+    const controlButtons = document.querySelectorAll('[data-move]');
+    const overlayTitle = overlay.querySelector('h2');
+    const overlayMain = overlay.querySelector('[data-overlay-main]');
+    const overlayDetail = overlay.querySelector('[data-overlay-detail]');
+
+    const DEFAULT_OVERLAY = {
+      title: 'Ready to Hop?',
+      main: 'Use the arrow keys (or the green controls) to hop to neighbouring lily pads. Wait for the gap, dodge the snakes, and reach flies before they blink out.',
+      detail: 'Catch five flies in a row to earn a bonus streak!',
+    };
+
+    const MOVE_COOLDOWN = 0.22; // seconds
+    const INVINCIBLE_TIME = 1.2; // seconds of safety after getting hit
+    const FLY_LIFETIME = [4, 6]; // seconds
+
+    const pads = createPads();
+    const lanes = [150, 300, 450];
+
+    const state = createInitialState();
+
+    window.addEventListener('keydown', handleKey);
+    window.addEventListener('blur', pauseGame);
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        pauseGame();
+      }
+    });
+
+    controlButtons.forEach(button => {
+      button.addEventListener('pointerdown', event => {
+        event.preventDefault();
+        queueMove(button.dataset.move);
+      });
+    });
+
+    startButton.addEventListener('click', () => {
+      if (!state.running) {
+        startGame();
+      } else {
+        resumeGame();
+      }
+    });
+
+    function setOverlayContent(title, main, detail) {
+      overlayTitle.textContent = title;
+      overlayMain.textContent = main;
+      overlayDetail.textContent = detail;
+    }
+
+    function createPads() {
+      const result = [];
+      const cols = 3;
+      const rows = 3;
+      const colPositions = [200, 400, 600];
+      const rowPositions = [150, 300, 450];
+      for (let r = 0; r < rows; r += 1) {
+        for (let c = 0; c < cols; c += 1) {
+          result.push({
+            x: colPositions[c],
+            y: rowPositions[r],
+            radius: 48,
+          });
+        }
+      }
+      return result;
+    }
+
+    function createInitialState() {
+      return {
+        running: false,
+        score: 0,
+        flies: 0,
+        lives: 3,
+        streak: 0,
+        lastTime: 0,
+        snakes: [],
+        fly: null,
+        flyTimer: 0,
+        frog: createFrog(),
+      };
+    }
+
+    function createFrog() {
+      const startPadIndex = 7; // bottom centre pad
+      const pad = pads[startPadIndex];
+      return {
+        currentPad: startPadIndex,
+        x: pad.x,
+        y: pad.y,
+        startX: pad.x,
+        startY: pad.y,
+        targetPad: startPadIndex,
+        moveTimer: 0,
+        moveDuration: MOVE_COOLDOWN,
+        invincible: 0,
+      };
+    }
+
+    function resetGame() {
+      state.running = false;
+      state.lastTime = 0;
+      state.score = 0;
+      state.flies = 0;
+      state.streak = 0;
+      state.lives = 3;
+      state.snakes.length = 0;
+      setupSnakes(state.snakes);
+      state.frog = createFrog();
+      spawnFly();
+      updateHud();
+      setOverlayContent(DEFAULT_OVERLAY.title, DEFAULT_OVERLAY.main, DEFAULT_OVERLAY.detail);
+    }
+
+    function initializeGame() {
+      resetGame();
+      overlay.classList.remove('hidden');
+      startButton.textContent = 'Start hopping';
+      render();
+    }
+
+    function startGame() {
+      overlay.classList.add('hidden');
+      resetGame();
+      startButton.textContent = 'Resume';
+      state.running = true;
+      state.lastTime = performance.now();
+      requestAnimationFrame(loop);
+    }
+
+    function resumeGame() {
+      overlay.classList.add('hidden');
+      state.running = true;
+      state.lastTime = performance.now();
+      requestAnimationFrame(loop);
+    }
+
+    function pauseGame() {
+      if (!state.running) return;
+      state.running = false;
+      overlay.classList.remove('hidden');
+      setOverlayContent('Paused', 'Snakes are circling. Tap Resume when you are ready to leap again!', 'Tip: watch the gaps in each lane.');
+      startButton.textContent = 'Resume';
+    }
+
+    function endGame() {
+      state.running = false;
+      overlay.classList.remove('hidden');
+      setOverlayContent('Game Over', `You caught ${state.flies} flies. Dodge the snakes and try again!`, 'Press Play again to restart the pond.');
+      startButton.textContent = 'Play again';
+    }
+
+    function handleKey(event) {
+      if (event.key === 'ArrowUp' || event.key === 'w') {
+        queueMove('up');
+      } else if (event.key === 'ArrowDown' || event.key === 's') {
+        queueMove('down');
+      } else if (event.key === 'ArrowLeft' || event.key === 'a') {
+        queueMove('left');
+      } else if (event.key === 'ArrowRight' || event.key === 'd') {
+        queueMove('right');
+      } else if (event.key === 'Enter' && !state.running) {
+        startButton.click();
+      }
+    }
+
+    function queueMove(direction) {
+      if (!state.running) return;
+      const frog = state.frog;
+      if (frog.moveTimer > 0) {
+        return;
+      }
+      const { row, col } = indexToRowCol(frog.currentPad);
+      let targetRow = row;
+      let targetCol = col;
+      switch (direction) {
+        case 'up':
+          targetRow = Math.max(0, row - 1);
+          break;
+        case 'down':
+          targetRow = Math.min(2, row + 1);
+          break;
+        case 'left':
+          targetCol = Math.max(0, col - 1);
+          break;
+        case 'right':
+          targetCol = Math.min(2, col + 1);
+          break;
+        default:
+          return;
+      }
+      const targetIndex = rowColToIndex(targetRow, targetCol);
+      if (targetIndex === frog.currentPad) {
+        return;
+      }
+      frog.targetPad = targetIndex;
+      frog.startX = frog.x;
+      frog.startY = frog.y;
+      frog.moveTimer = frog.moveDuration;
+    }
+
+    function indexToRowCol(index) {
+      return {
+        row: Math.floor(index / 3),
+        col: index % 3,
+      };
+    }
+
+    function rowColToIndex(row, col) {
+      return row * 3 + col;
+    }
+
+    function setupSnakes(snakes) {
+      const laneCount = lanes.length;
+      for (let i = 0; i < laneCount; i += 1) {
+        const direction = i % 2 === 0 ? 1 : -1;
+        snakes.push(createSnake(i, direction));
+        snakes.push(createSnake(i, -direction));
+      }
+    }
+
+    function createSnake(laneIndex, direction) {
+      const laneY = lanes[laneIndex];
+      const length = randomRange(120, 180);
+      const speed = randomRange(70, 130);
+      const startX = direction > 0 ? -length : canvas.width + length;
+      return {
+        laneIndex,
+        x: startX,
+        y: laneY,
+        length,
+        direction,
+        speed,
+        thickness: 26,
+        cooldown: randomRange(0.3, 0.8),
+      };
+    }
+
+    function spawnFly() {
+      const targetPads = pads.filter(pad => pad.y <= 300);
+      const pad = targetPads[Math.floor(Math.random() * targetPads.length)];
+      state.fly = {
+        x: pad.x,
+        y: pad.y - 28,
+        padIndex: pads.indexOf(pad),
+      };
+      state.flyTimer = randomRange(...FLY_LIFETIME);
+    }
+
+    function updateHud() {
+      scoreEl.textContent = state.score.toString().padStart(4, '0');
+      fliesEl.textContent = state.flies.toString().padStart(2, '0');
+      livesEl.textContent = state.lives.toString();
+    }
+
+    function loop(timestamp) {
+      if (!state.running) {
+        return;
+      }
+      const delta = Math.min((timestamp - state.lastTime) / 1000, 0.05);
+      state.lastTime = timestamp;
+
+      update(delta);
+      render();
+
+      requestAnimationFrame(loop);
+    }
+
+    function update(delta) {
+      const frog = state.frog;
+      if (frog.moveTimer > 0) {
+        frog.moveTimer -= delta;
+        const progress = 1 - Math.max(0, frog.moveTimer) / frog.moveDuration;
+        const eased = easeOutBack(progress);
+        const targetPad = pads[frog.targetPad];
+        frog.x = frog.startX + (targetPad.x - frog.startX) * eased;
+        frog.y = frog.startY + (targetPad.y - frog.startY) * eased;
+        if (frog.moveTimer <= 0) {
+          frog.currentPad = frog.targetPad;
+          frog.x = targetPad.x;
+          frog.y = targetPad.y;
+        }
+      }
+
+      frog.invincible = Math.max(0, frog.invincible - delta);
+
+      updateSnakes(delta);
+      updateFly(delta);
+      detectCollisions();
+    }
+
+    function updateSnakes(delta) {
+      for (const snake of state.snakes) {
+        if (snake.cooldown > 0) {
+          snake.cooldown -= delta;
+          continue;
+        }
+        snake.x += snake.speed * snake.direction * delta;
+        const offscreen = snake.direction > 0 ? snake.x - snake.length > canvas.width + 60 : snake.x + snake.length < -60;
+        if (offscreen) {
+          snake.direction *= -1;
+          snake.speed = randomRange(80, 150);
+          snake.length = randomRange(110, 170);
+          snake.cooldown = randomRange(0.5, 1.5);
+          snake.x = snake.direction > 0 ? -snake.length : canvas.width + snake.length;
+        }
+      }
+    }
+
+    function updateFly(delta) {
+      if (!state.fly) {
+        state.flyTimer -= delta;
+        if (state.flyTimer <= 0) {
+          spawnFly();
+        }
+        return;
+      }
+      state.flyTimer -= delta;
+      if (state.flyTimer <= 0) {
+        state.streak = 0;
+        state.fly = null;
+        state.flyTimer = randomRange(0.8, 1.5);
+      }
+    }
+
+    function detectCollisions() {
+      const frog = state.frog;
+      if (state.fly && frog.currentPad === state.fly.padIndex && frog.moveTimer <= 0) {
+        state.flies += 1;
+        state.streak += 1;
+        const baseScore = 100;
+        const streakBonus = Math.max(0, state.streak - 1) * 25;
+        state.score += baseScore + streakBonus;
+        state.fly = null;
+        state.flyTimer = randomRange(0.8, 1.4);
+        pulseText(fliesEl);
+        pulseText(scoreEl);
+        updateHud();
+      }
+
+      if (frog.invincible > 0) {
+        return;
+      }
+
+      for (const snake of state.snakes) {
+        const halfLength = snake.length / 2;
+        const snakeRect = {
+          x1: snake.x - halfLength,
+          x2: snake.x + halfLength,
+          y1: snake.y - snake.thickness / 2,
+          y2: snake.y + snake.thickness / 2,
+        };
+        if (frog.x > snakeRect.x1 - 28 && frog.x < snakeRect.x2 + 28 && frog.y > snakeRect.y1 - 28 && frog.y < snakeRect.y2 + 28) {
+          state.lives -= 1;
+          state.streak = 0;
+          updateHud();
+          pulseText(livesEl);
+          frog.invincible = INVINCIBLE_TIME;
+          frog.currentPad = 7;
+          frog.targetPad = 7;
+          frog.x = pads[7].x;
+          frog.y = pads[7].y;
+          frog.moveTimer = 0;
+          if (state.lives <= 0) {
+            endGame();
+          }
+          break;
+        }
+      }
+    }
+
+    function render() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      drawBackground();
+      drawPads();
+      drawFly();
+      drawSnakes();
+      drawFrog();
+    }
+
+    function drawBackground() {
+      const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+      gradient.addColorStop(0, '#10253f');
+      gradient.addColorStop(1, '#04121a');
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      ctx.fillStyle = 'rgba(15, 118, 110, 0.25)';
+      ctx.beginPath();
+      ctx.ellipse(canvas.width / 2, canvas.height * 0.78, 340, 110, 0, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    function drawPads() {
+      for (const pad of pads) {
+        const radial = ctx.createRadialGradient(pad.x - 12, pad.y - 12, 12, pad.x, pad.y, pad.radius);
+        radial.addColorStop(0, '#4ade80');
+        radial.addColorStop(1, '#166534');
+        ctx.fillStyle = radial;
+        ctx.beginPath();
+        ctx.ellipse(pad.x, pad.y, pad.radius + 4, pad.radius, 0, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.strokeStyle = 'rgba(15, 118, 110, 0.45)';
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.ellipse(pad.x, pad.y, pad.radius + 6, pad.radius + 3, 0, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+    }
+
+    function drawSnakes() {
+      for (const snake of state.snakes) {
+        if (snake.cooldown > 0) continue;
+        const halfLength = snake.length / 2;
+        ctx.lineWidth = snake.thickness;
+        const gradient = ctx.createLinearGradient(snake.x - halfLength, snake.y, snake.x + halfLength, snake.y);
+        gradient.addColorStop(0, '#65a30d');
+        gradient.addColorStop(1, '#166534');
+        ctx.strokeStyle = gradient;
+        ctx.lineCap = 'round';
+        ctx.beginPath();
+        ctx.moveTo(snake.x - halfLength, snake.y);
+        ctx.lineTo(snake.x + halfLength, snake.y);
+        ctx.stroke();
+
+        ctx.fillStyle = '#f97316';
+        const headX = snake.direction > 0 ? snake.x + halfLength : snake.x - halfLength;
+        ctx.beginPath();
+        ctx.moveTo(headX, snake.y);
+        ctx.lineTo(headX + 18 * snake.direction, snake.y - 6);
+        ctx.lineTo(headX + 18 * snake.direction, snake.y + 6);
+        ctx.closePath();
+        ctx.fill();
+      }
+    }
+
+    function drawFly() {
+      if (!state.fly) return;
+      const flicker = 0.6 + Math.sin(performance.now() / 120) * 0.2;
+      ctx.save();
+      ctx.translate(state.fly.x, state.fly.y);
+      ctx.fillStyle = `rgba(254, 240, 138, ${0.7 + flicker * 0.3})`;
+      ctx.beginPath();
+      ctx.arc(0, 0, 12 + flicker * 4, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = `rgba(250, 204, 21, ${0.9})`;
+      ctx.beginPath();
+      ctx.arc(0, 0, 8, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    function drawFrog() {
+      const frog = state.frog;
+      ctx.save();
+      ctx.translate(frog.x, frog.y);
+      ctx.fillStyle = frog.invincible > 0 ? 'rgba(190, 242, 100, 0.85)' : '#34d399';
+      ctx.beginPath();
+      ctx.ellipse(0, 0, 34, 28, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = '#bbf7d0';
+      ctx.beginPath();
+      ctx.ellipse(-16, -10, 12, 14, 0, 0, Math.PI * 2);
+      ctx.ellipse(16, -10, 12, 14, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = '#1f2937';
+      ctx.beginPath();
+      ctx.arc(-16, -10, 6, 0, Math.PI * 2);
+      ctx.arc(16, -10, 6, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.strokeStyle = '#0f172a';
+      ctx.lineWidth = 3;
+      ctx.beginPath();
+      ctx.arc(0, 10, 12, 0, Math.PI);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    function pulseText(element) {
+      element.animate([
+        { transform: 'scale(1)', color: '#fef08a' },
+        { transform: 'scale(1.2)', color: '#bef264' },
+        { transform: 'scale(1)', color: '#fef08a' },
+      ], {
+        duration: 360,
+        easing: 'ease-out',
+      });
+    }
+
+    function randomRange(min, max) {
+      return Math.random() * (max - min) + min;
+    }
+
+    function easeOutBack(t) {
+      const c1 = 1.70158;
+      const c3 = c1 + 1;
+      return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+    }
+
+    initializeGame();
+  </script>
+</body>
+</html>

--- a/public/demos/frog-fly-feast/index.html
+++ b/public/demos/frog-fly-feast/index.html
@@ -251,10 +251,11 @@
       });
     });
 
+    // Route overlay button clicks based on the current flow state so pauses resume and everything else restarts.
     startButton.addEventListener('click', () => {
-      if (!state.running) {
+      if (state.phase === 'ready' || state.phase === 'gameover') {
         startGame();
-      } else {
+      } else if (state.phase === 'paused') {
         resumeGame();
       }
     });
@@ -283,9 +284,13 @@
       return result;
     }
 
+    /**
+     * Build a fresh baseline for the game state so we can reuse the same shape between runs.
+     */
     function createInitialState() {
       return {
         running: false,
+        phase: 'ready',
         score: 0,
         flies: 0,
         lives: 3,
@@ -314,16 +319,11 @@
       };
     }
 
+    // Reset the existing state object so any references stay valid between restarts.
     function resetGame() {
-      state.running = false;
-      state.lastTime = 0;
-      state.score = 0;
-      state.flies = 0;
-      state.streak = 0;
-      state.lives = 3;
-      state.snakes.length = 0;
+      const freshState = createInitialState();
+      Object.assign(state, freshState);
       setupSnakes(state.snakes);
-      state.frog = createFrog();
       spawnFly();
       updateHud();
       setOverlayContent(DEFAULT_OVERLAY.title, DEFAULT_OVERLAY.main, DEFAULT_OVERLAY.detail);
@@ -337,9 +337,10 @@
     }
 
     function startGame() {
-      overlay.classList.add('hidden');
       resetGame();
+      overlay.classList.add('hidden');
       startButton.textContent = 'Resume';
+      state.phase = 'running';
       state.running = true;
       state.lastTime = performance.now();
       requestAnimationFrame(loop);
@@ -347,6 +348,7 @@
 
     function resumeGame() {
       overlay.classList.add('hidden');
+      state.phase = 'running';
       state.running = true;
       state.lastTime = performance.now();
       requestAnimationFrame(loop);
@@ -355,6 +357,7 @@
     function pauseGame() {
       if (!state.running) return;
       state.running = false;
+      state.phase = 'paused';
       overlay.classList.remove('hidden');
       setOverlayContent('Paused', 'Snakes are circling. Tap Resume when you are ready to leap again!', 'Tip: watch the gaps in each lane.');
       startButton.textContent = 'Resume';
@@ -362,6 +365,7 @@
 
     function endGame() {
       state.running = false;
+      state.phase = 'gameover';
       overlay.classList.remove('hidden');
       setOverlayContent('Game Over', `You caught ${state.flies} flies. Dodge the snakes and try again!`, 'Press Play again to restart the pond.');
       startButton.textContent = 'Play again';

--- a/public/games/frog-fly-feast/hero.svg
+++ b/public/games/frog-fly-feast/hero.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+  <title id="title">Frog Fly Feast hero art</title>
+  <desc id="desc">A cheerful frog leaping across a moonlit pond, avoiding snakes while catching glowing flies.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0f1535" />
+      <stop offset="100%" stop-color="#1c3658" />
+    </linearGradient>
+    <radialGradient id="moonGlow" cx="0.76" cy="0.18" r="0.35">
+      <stop offset="0%" stop-color="#fef9c3" stop-opacity="0.95" />
+      <stop offset="60%" stop-color="#fde047" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#fde047" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="pond" cx="0.5" cy="0.6" r="0.6">
+      <stop offset="0%" stop-color="#175e6b" />
+      <stop offset="65%" stop-color="#0f4151" />
+      <stop offset="100%" stop-color="#092835" />
+    </radialGradient>
+    <linearGradient id="snakeBody" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#52a34a" />
+      <stop offset="100%" stop-color="#2d6b33" />
+    </linearGradient>
+    <filter id="softGlow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="8" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="1200" height="720" fill="url(#sky)" />
+  <rect width="1200" height="720" fill="url(#moonGlow)" />
+  <ellipse cx="960" cy="120" rx="110" ry="110" fill="#fef3c7" opacity="0.7" />
+  <ellipse cx="600" cy="520" rx="460" ry="220" fill="url(#pond)" />
+  <g fill="#0c2534" opacity="0.55">
+    <ellipse cx="220" cy="560" rx="120" ry="38" />
+    <ellipse cx="1040" cy="590" rx="140" ry="42" />
+  </g>
+  <g>
+    <path d="M180 350 Q230 300 320 320" stroke="url(#snakeBody)" stroke-width="24" stroke-linecap="round" fill="none" />
+    <path d="M260 340 Q270 325 288 330" stroke="#f87171" stroke-width="10" stroke-linecap="round" fill="none" />
+    <circle cx="320" cy="320" r="16" fill="#facc15" />
+    <circle cx="320" cy="320" r="8" fill="#1c1917" />
+  </g>
+  <g>
+    <path d="M860 420 Q930 470 1040 450" stroke="url(#snakeBody)" stroke-width="26" stroke-linecap="round" fill="none" />
+    <path d="M960 448 Q974 440 982 446" stroke="#f87171" stroke-width="10" stroke-linecap="round" fill="none" />
+    <circle cx="1040" cy="450" r="18" fill="#facc15" />
+    <circle cx="1040" cy="450" r="9" fill="#1c1917" />
+  </g>
+  <g filter="url(#softGlow)">
+    <circle cx="420" cy="200" r="14" fill="#fde047" />
+    <circle cx="520" cy="180" r="10" fill="#fde047" opacity="0.8" />
+    <circle cx="700" cy="160" r="12" fill="#fde047" opacity="0.9" />
+  </g>
+  <g>
+    <ellipse cx="600" cy="480" rx="130" ry="48" fill="#0d2531" opacity="0.6" />
+    <g transform="translate(600 420)">
+      <g filter="url(#softGlow)">
+        <ellipse cx="0" cy="45" rx="82" ry="30" fill="#1f5137" opacity="0.85" />
+      </g>
+      <g>
+        <ellipse cx="0" cy="0" rx="68" ry="44" fill="#30b26d" />
+        <ellipse cx="-28" cy="-8" rx="20" ry="18" fill="#fef3c7" />
+        <ellipse cx="28" cy="-8" rx="20" ry="18" fill="#fef3c7" />
+        <circle cx="-28" cy="-8" r="7" fill="#1c1917" />
+        <circle cx="28" cy="-8" r="7" fill="#1c1917" />
+        <path d="M-36 18 Q0 42 36 18" fill="#f97316" />
+        <path d="M-52 -20 Q0 -64 56 -22" fill="#22c55e" />
+        <circle cx="60" cy="-12" r="12" fill="#fde047" />
+        <circle cx="-66" cy="-14" r="14" fill="#fde047" />
+      </g>
+    </g>
+  </g>
+  <text x="120" y="640" fill="#fef9c3" font-family="'Baloo 2', 'Nunito', sans-serif" font-size="64" font-weight="700">
+    Frog Fly Feast
+  </text>
+  <text x="120" y="684" fill="#a5f3fc" font-family="'Nunito', sans-serif" font-size="28">
+    Time leaps between snakes and snap up glowing flies.
+  </text>
+</svg>

--- a/public/games/frog-fly-feast/s1.svg
+++ b/public/games/frog-fly-feast/s1.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+  <title id="title">Frog Fly Feast gameplay snapshot</title>
+  <desc id="desc">Gameplay mockup with frog on a lily pad, snakes gliding across lanes, and flies glowing above.</desc>
+  <defs>
+    <linearGradient id="water" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0d3b4a" />
+      <stop offset="100%" stop-color="#051f28" />
+    </linearGradient>
+    <radialGradient id="pad" cx="0.5" cy="0.5" r="0.6">
+      <stop offset="0%" stop-color="#42c786" />
+      <stop offset="100%" stop-color="#1d7a4a" />
+    </radialGradient>
+    <linearGradient id="snake" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#60c46b" />
+      <stop offset="100%" stop-color="#2f8140" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="720" fill="url(#water)" />
+  <g opacity="0.8" fill="#05232c">
+    <ellipse cx="600" cy="640" rx="380" ry="70" />
+    <ellipse cx="320" cy="520" rx="180" ry="50" />
+    <ellipse cx="900" cy="560" rx="200" ry="54" />
+  </g>
+  <g transform="translate(0,80)" opacity="0.3">
+    <text x="240" y="72" font-family="'Nunito', sans-serif" font-size="28" fill="#a5f3fc">Combo x2!</text>
+  </g>
+  <g stroke="#0f172a" stroke-width="6" stroke-linecap="round">
+    <path d="M120 260 Q300 220 520 260" fill="none" stroke="url(#snake)" />
+    <path d="M680 360 Q900 400 1080 360" fill="none" stroke="url(#snake)" />
+  </g>
+  <g fill="#fde047" opacity="0.9">
+    <circle cx="240" cy="220" r="14" />
+    <circle cx="840" cy="180" r="11" />
+    <circle cx="960" cy="260" r="16" />
+  </g>
+  <g transform="translate(600 420)">
+    <ellipse cx="0" cy="72" rx="120" ry="38" fill="#082c34" opacity="0.6" />
+    <ellipse cx="0" cy="0" rx="90" ry="62" fill="url(#pad)" />
+    <g transform="translate(0,-10)">
+      <ellipse cx="-30" cy="-8" rx="22" ry="18" fill="#fef3c7" />
+      <ellipse cx="30" cy="-8" rx="22" ry="18" fill="#fef3c7" />
+      <circle cx="-30" cy="-8" r="7" fill="#0f172a" />
+      <circle cx="30" cy="-8" r="7" fill="#0f172a" />
+      <path d="M-36 18 Q0 48 36 18" fill="#f97316" />
+      <path d="M-60 -20 Q0 -78 64 -20" fill="#22c55e" />
+    </g>
+  </g>
+  <g font-family="'Nunito', sans-serif" font-weight="700" fill="#e0f2fe">
+    <text x="80" y="92" font-size="52">Frog Fly Feast</text>
+    <text x="80" y="142" font-size="28" fill="#bae6fd">Leap between lily pads, dodge snakes, and grab glowing flies.</text>
+  </g>
+  <g font-family="'Roboto Mono', monospace" font-size="28" fill="#bef264">
+    <text x="80" y="200">Score  01250</text>
+    <text x="80" y="240" fill="#fca5a5">Snakes dodged  07</text>
+    <text x="80" y="280" fill="#fef08a">Flies caught  05</text>
+  </g>
+</svg>

--- a/src/data/games.json
+++ b/src/data/games.json
@@ -279,5 +279,25 @@
     "engine": "vanilla-js",
     "version": "0.1.0",
     "status": "released"
+  },
+  {
+    "slug": "frog-fly-feast",
+    "title": "Frog Fly Feast",
+    "tags": [
+      "timing",
+      "dodge",
+      "reflex"
+    ],
+    "description": "Hop across the pond, dodge weaving snakes, and time leaps to snap up glowing flies.",
+    "description_it": "Salta tra le ninfee, schiva i serpenti ondulanti e cronometra i balzi per catturare le lucciole.",
+    "hero": "/games/frog-fly-feast/hero.svg",
+    "screenshots": [
+      "/games/frog-fly-feast/s1.svg"
+    ],
+    "demoPath": "/demos/frog-fly-feast/index.html",
+    "gameType": "html5",
+    "engine": "vanilla-js",
+    "version": "0.1.0",
+    "status": "released"
   }
 ]


### PR DESCRIPTION
## Summary
- create a helper to generate the initial Frog Fly Feast state and reuse it during resets
- centralize reset logic so the game loop always starts from a clean baseline and ensure the overlay/button default text is restored on load
- invoke an initializeGame routine on module load so the canvas preview is populated without depending on partially constructed state

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f3592040c8832dbb4519112931c35f